### PR TITLE
feat: forward MCP headers to Sonilo API

### DIFF
--- a/src/sonilo_mcp/api.py
+++ b/src/sonilo_mcp/api.py
@@ -13,6 +13,7 @@ import shutil
 import subprocess
 import sys
 import time
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
 from pathlib import Path
 from typing import AsyncIterator
 from urllib.parse import urlparse
@@ -22,6 +23,20 @@ from mcp.server.fastmcp import FastMCP
 from mcp.types import TextContent
 
 mcp = FastMCP("Sonilo")
+
+try:
+    _CLIENT_VERSION = _pkg_version("sonilo-mcp")
+except PackageNotFoundError:  # running from source without an installed dist
+    _CLIENT_VERSION = "unknown"
+
+# Sent on every request so the backend can attribute traffic to the MCP.
+# Only X-Sonilo-Client is trusted by the backend for statistics; User-Agent
+# is a convenience so the marker also shows up in access logs.
+_CLIENT_HEADERS = {
+    "X-Sonilo-Client": "mcp",
+    "X-Sonilo-Client-Version": _CLIENT_VERSION,
+    "User-Agent": f"sonilo-mcp/{_CLIENT_VERSION}",
+}
 
 
 # ---------- Configuration ----------
@@ -253,7 +268,7 @@ async def _http_get_json(path: str, params: dict | None = None) -> dict:
     if not cfg["api_key"]:
         raise Exception(f"SONILO_API_KEY not set — see {_API_KEYS_URL}")
     url = cfg["api_url"].rstrip("/") + path
-    headers = {"Authorization": f"Bearer {cfg['api_key']}"}
+    headers = {"Authorization": f"Bearer {cfg['api_key']}", **_CLIENT_HEADERS}
 
     for attempt in (1, 2):
         try:
@@ -361,7 +376,7 @@ async def _post_streaming_generation(
     if not cfg["api_key"]:
         raise Exception(f"SONILO_API_KEY not set — see {_API_KEYS_URL}")
     url = cfg["api_url"].rstrip("/") + path
-    headers = {"Authorization": f"Bearer {cfg['api_key']}"}
+    headers = {"Authorization": f"Bearer {cfg['api_key']}", **_CLIENT_HEADERS}
 
     try:
         async with httpx.AsyncClient(timeout=cfg["timeout"]) as client:

--- a/src/sonilo_mcp/api.py
+++ b/src/sonilo_mcp/api.py
@@ -39,6 +39,30 @@ _CLIENT_HEADERS = {
 }
 
 
+def _host_headers() -> dict[str, str]:
+    """Best-effort headers identifying the MCP *host* app (Claude, Cursor,
+    Codex, …).
+
+    The host self-reports a ``clientInfo {name, version}`` during the MCP
+    ``initialize`` handshake; we read it from the live session and forward it
+    so the backend can attribute traffic to the host. Returns ``{}`` if the
+    context/session/clientInfo is unavailable for any reason — host
+    attribution must never break a request. Values are length-capped.
+    """
+    try:
+        info = mcp.get_context().session.client_params.clientInfo
+    except Exception:
+        return {}
+    out: dict[str, str] = {}
+    name = getattr(info, "name", None)
+    version = getattr(info, "version", None)
+    if name:
+        out["X-Sonilo-Client-Host"] = str(name)[:64]
+    if version:
+        out["X-Sonilo-Client-Host-Version"] = str(version)[:64]
+    return out
+
+
 # ---------- Configuration ----------
 
 def _get_config() -> dict:
@@ -268,7 +292,7 @@ async def _http_get_json(path: str, params: dict | None = None) -> dict:
     if not cfg["api_key"]:
         raise Exception(f"SONILO_API_KEY not set — see {_API_KEYS_URL}")
     url = cfg["api_url"].rstrip("/") + path
-    headers = {"Authorization": f"Bearer {cfg['api_key']}", **_CLIENT_HEADERS}
+    headers = {"Authorization": f"Bearer {cfg['api_key']}", **_CLIENT_HEADERS, **_host_headers()}
 
     for attempt in (1, 2):
         try:
@@ -376,7 +400,7 @@ async def _post_streaming_generation(
     if not cfg["api_key"]:
         raise Exception(f"SONILO_API_KEY not set — see {_API_KEYS_URL}")
     url = cfg["api_url"].rstrip("/") + path
-    headers = {"Authorization": f"Bearer {cfg['api_key']}", **_CLIENT_HEADERS}
+    headers = {"Authorization": f"Bearer {cfg['api_key']}", **_CLIENT_HEADERS, **_host_headers()}
 
     try:
         async with httpx.AsyncClient(timeout=cfg["timeout"]) as client:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1183,3 +1183,52 @@ async def test_post_streaming_sends_client_headers(monkeypatch, output_dir):
     assert req.headers["X-Sonilo-Client"] == "mcp"
     assert req.headers["X-Sonilo-Client-Version"]
     assert req.headers["User-Agent"].startswith("sonilo-mcp/")
+
+
+@respx.mock
+async def test_http_get_json_sends_host_headers_from_clientinfo(monkeypatch):
+    monkeypatch.setenv("SONILO_API_KEY", "k1")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    import sonilo_mcp.api as api
+
+    class _Info:
+        name = "claude-ai"
+        version = "1.2.3"
+
+    class _Params:
+        clientInfo = _Info()
+
+    class _Session:
+        client_params = _Params()
+
+    class _Ctx:
+        session = _Session()
+
+    monkeypatch.setattr(api.mcp, "get_context", lambda: _Ctx())
+    route = respx.get("https://api.test.local/v1/foo").mock(
+        return_value=httpx.Response(200, json={"ok": True})
+    )
+    await api._http_get_json("/v1/foo")
+    req = route.calls[0].request
+    assert req.headers["X-Sonilo-Client-Host"] == "claude-ai"
+    assert req.headers["X-Sonilo-Client-Host-Version"] == "1.2.3"
+
+
+@respx.mock
+async def test_http_get_json_omits_host_headers_when_no_context(monkeypatch):
+    monkeypatch.setenv("SONILO_API_KEY", "k1")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    import sonilo_mcp.api as api
+
+    def _boom():
+        raise RuntimeError("no active request context")
+
+    monkeypatch.setattr(api.mcp, "get_context", _boom)
+    route = respx.get("https://api.test.local/v1/foo").mock(
+        return_value=httpx.Response(200, json={"ok": True})
+    )
+    await api._http_get_json("/v1/foo")
+    req = route.calls[0].request
+    assert "X-Sonilo-Client-Host" not in req.headers
+    # The base client marker is still present — only host attribution is absent.
+    assert req.headers["X-Sonilo-Client"] == "mcp"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1142,3 +1142,44 @@ async def test_get_max_upload_size_mb_falls_back_on_failure(monkeypatch):
     _reset_services_cache()
     out = await _get_max_upload_size_mb()
     assert out == 300
+
+
+@respx.mock
+async def test_http_get_json_sends_client_headers(monkeypatch):
+    monkeypatch.setenv("SONILO_API_KEY", "k1")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    route = respx.get("https://api.test.local/v1/foo").mock(
+        return_value=httpx.Response(200, json={"ok": True})
+    )
+    from sonilo_mcp.api import _http_get_json
+    await _http_get_json("/v1/foo")
+    req = route.calls[0].request
+    assert req.headers["X-Sonilo-Client"] == "mcp"
+    assert req.headers["X-Sonilo-Client-Version"]  # non-empty
+    assert req.headers["User-Agent"].startswith("sonilo-mcp/")
+
+
+@respx.mock
+async def test_post_streaming_sends_client_headers(monkeypatch, output_dir):
+    import base64
+    import json as _json
+    monkeypatch.setenv("SONILO_API_KEY", "k1")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    ndjson = (
+        _json.dumps({
+            "type": "audio_chunk", "stream_index": 0, "num_streams": 1,
+            "data": base64.b64encode(b"x").decode(),
+        }) + "\n"
+        + _json.dumps({"type": "complete"}) + "\n"
+    ).encode()
+    route = respx.post("https://api.test.local/v1/text-to-music").mock(
+        return_value=httpx.Response(200, content=ndjson)
+    )
+    from sonilo_mcp.api import _post_streaming_generation
+    await _post_streaming_generation(
+        "/v1/text-to-music", output_dir, data={"prompt": "p", "duration": 5}
+    )
+    req = route.calls[0].request
+    assert req.headers["X-Sonilo-Client"] == "mcp"
+    assert req.headers["X-Sonilo-Client-Version"]
+    assert req.headers["User-Agent"].startswith("sonilo-mcp/")


### PR DESCRIPTION
## Summary

Adds client-attribution headers to outgoing Sonilo API requests so the backend can identify which MCP host is driving traffic.

- **`X-Sonilo-Client` marker headers** sent on API requests (`9d26565`).
- **`X-Sonilo-Client-Host`** forwards the host app's self-reported  `{name, version}` read from the MCP session, best-effort and length-capped, so the backend can attribute traffic to Claude / Cursor / Codex / etc. Never breaks a request if the context/session is unavailable (`a7475c3`).

## Testing

- Added `tests/test_api.py` covering the new header behavior.