### PR TITLE
Highlight licensing (Shutterstock) and video-to-music features

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 An MCP (Model Context Protocol) server that exposes [Sonilo](https://platform.sonilo.com)'s AI music generation API to MCP-compatible clients (Claude Desktop, Codex).
 
+## Why Sonilo
+
+- **Video-to-music** — give it a video and Sonilo composes a full-length score matched to its pacing, motion, and emotion. Transitions and beat drops align to your cut points, and the track matches the video's duration exactly — no prompts or manual syncing required.
+- **Text-to-music** — generate tracks from a text description (genre, mood, tempo, instrumentation) at an exact duration (1–360s).
+- **Fully licensed, commercial-safe** — music licensed via Shutterstock; every generated track is cleared for commercial use on social, brand content, and advertising, with no Content ID worries.
+- **Pay as you go** — billed only for the seconds of music you generate; new accounts get free credits on signup.
+
 ### Audio Playback Dependencies
 
 The `play_audio` tool requires PortAudio at runtime (for `sounddevice`). On macOS/Linux, install via:

--- a/src/sonilo_mcp/api.py
+++ b/src/sonilo_mcp/api.py
@@ -446,7 +446,9 @@ async def _post_streaming_generation(
 @mcp.tool(
     description=(
         "Generate music from a text prompt and save the resulting audio "
-        "file(s) to a local directory.\n\n"
+        "file(s) to a local directory. Generated tracks are fully licensed "
+        "(music licensed via Shutterstock) and cleared for commercial use "
+        "on social, brand content, and advertising.\n\n"
         "⚠️ COST WARNING: This tool makes an API call to Sonilo which may "
         "incur charges. Only use when explicitly requested by the user.\n\n"
         "Args:\n"
@@ -510,8 +512,13 @@ async def _get_max_upload_size_mb() -> int:
 
 @mcp.tool(
     description=(
-        "Generate music that matches the soundtrack of a video. Provide "
-        "either a local video file path or a publicly accessible video URL.\n\n"
+        "Generate an original score for a video: Sonilo analyzes the video's "
+        "pacing, motion, and emotion, aligns transitions and beat drops to "
+        "its cut points, and matches the video's duration exactly. Provide "
+        "either a local video file path or a publicly accessible video URL. "
+        "Generated tracks are fully licensed (music licensed via "
+        "Shutterstock) and cleared for commercial use on social, brand "
+        "content, and advertising.\n\n"
         "⚠️ COST WARNING: This tool makes an API call to Sonilo which may "
         "incur charges. Only use when explicitly requested by the user.\n\n"
         "Args:\n"


### PR DESCRIPTION
## What

- **README**: adds a "Why Sonilo" section up top: video-to-music (beat sync, duration matching), text-to-music at exact duration, fully licensed commercial-safe output (music licensed via Shutterstock), pay-as-you-go with free signup credits.
- **Tool descriptions** (`text_to_music`, `video_to_music`): state the licensing/commercial-use clearance and describe video-to-music accurately (pacing/motion/emotion analysis, transitions aligned to cut points, duration matched). These descriptions are what MCP hosts show to agents and users, so the licensing guarantee is now visible at the point of use.

## Testing

```
92 passed
```

No behavior changes — docs and description strings only.