### PR TITLE
README: lead with video_to_music, add Claude Code quickstart and demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # Sonilo MCP Server
 
-An MCP (Model Context Protocol) server that exposes [Sonilo](https://platform.sonilo.com)'s AI music generation API to MCP-compatible clients (Claude Desktop, Codex).
+An MCP (Model Context Protocol) server that exposes [Sonilo](https://sonilo.com)'s licensed video-to-music API to MCP-compatible clients (Claude Code, Claude Desktop, Codex).
+
+The flagship tool is **`video_to_music`**: hand it your finished video and it composes an original soundtrack matched to the cut — the music follows the pacing, emotion, and edits because the model saw them. Length matches the video automatically. Every track is licensed and safe for commercial use (terms apply). `text_to_music` is also available for fixed-length tracks with no video to match.
+
+**▶ [Example result](https://github.com/cindyxu1030/sonilo-video-to-music-cookbook/blob/main/assets/demo-trailer.mp4)** — an AI-generated trailer with its soundtrack composed by `video_to_music` from the assembled cut. For recipes covering any AI-video pipeline (stitch → grade → add music → mux), see the [Sonilo video-to-music cookbook](https://github.com/cindyxu1030/sonilo-video-to-music-cookbook).
+
+## Quickstart with Claude Code
+
+```bash
+claude mcp add sonilo --env SONILO_API_KEY=sks_... -- uvx sonilo-mcp
+```
+
+Get your API key from the [Sonilo dashboard](https://platform.sonilo.com/dashboard/api-keys), then start a session and ask, e.g. *"Make background music that matches this video: `~/Desktop/promo.mp4`."*
 
 ### Audio Playback Dependencies
 
@@ -77,10 +89,11 @@ The `play_audio` tool requires PortAudio at runtime (for `sounddevice`). On macO
 
 Once the server is connected, just ask your assistant in natural language. For example:
 
-- *"Use Sonilo mcp to generate 30 seconds of upbeat lo-fi hip-hop for a study playlist and save it to my Desktop."*
-- *"Use Sonilo to write an epic orchestral cinematic track, about 60 seconds long."*
 - *"Make background music that matches this video: `~/Desktop/promo.mp4`."*
 - *"Compose music for `https://example.com/clip.mp4` with a calm, ambient style."*
+- *"I stitched my AI-generated clips into `~/Desktop/trailer.mp4` — add a soundtrack that matches the cut."*
+- *"Use Sonilo mcp to generate 30 seconds of upbeat lo-fi hip-hop for a study playlist and save it to my Desktop."*
+- *"Use Sonilo to write an epic orchestral cinematic track, about 60 seconds long."*
 - *"What Sonilo services and limits does my account have?"*
 - *"Show my Sonilo usage for the last 7 days."*
 - *"Play the track you just generated."*


### PR DESCRIPTION
Positioning pass on the README (no code changes):

- Intro now leads with `video_to_music` and the approved category wording ("licensed video-to-music") instead of "AI music generation API", per the brand/legal wording decisions (2026-07-07/08).
- Adds a Claude Code quickstart (`claude mcp add sonilo ...`) — previously only Claude Desktop and Codex were covered.
- Links the demo trailer and the public video-to-music cookbook.
- Example prompts reordered so video-matched examples come first.

All technical content (config, confinement, tools table, errors) untouched.

— Cindy