### PR TITLE
MCP Registry publish kit: server.json + smithery.yaml + publishing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Sonilo MCP Server
 
+<!-- mcp-name: io.github.sonilo-ai/sonilo-mcp -->
+
 An MCP (Model Context Protocol) server that exposes [Sonilo](https://platform.sonilo.com)'s AI music generation API to MCP-compatible clients (Claude Desktop, Codex).
 
 ### Audio Playback Dependencies

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -1,0 +1,43 @@
+# Publishing sonilo-mcp to the MCP Registry + directories
+
+Goal: make `sonilo-mcp` discoverable everywhere agent developers look for MCP servers. The official MCP Registry is the master copy — the big aggregators (Glama, PulseMCP, and MCP clients) sync from it.
+
+## One-time sequence (order matters)
+
+### 1. Release 0.2.1 to PyPI first
+
+The registry verifies PyPI ownership by finding the `mcp-name` comment in the package description **on PyPI**. This repo's README now carries `<!-- mcp-name: io.github.sonilo-ai/sonilo-mcp -->`, but the check runs against the published package — so cut a release that includes it:
+
+- bump `pyproject.toml` version to `0.2.1`
+- release to PyPI as usual (the existing release workflow)
+
+### 2. Publish to the official MCP Registry
+
+Requires a GitHub account that is a member of the `sonilo-ai` org (the `io.github.sonilo-ai/*` namespace is verified through GitHub auth).
+
+```bash
+# install the publisher CLI
+brew install mcp-publisher
+# or: curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher && sudo mv mcp-publisher /usr/local/bin/
+
+# from the repo root (server.json is already here)
+mcp-publisher login github
+mcp-publisher publish
+```
+
+Verify: https://registry.modelcontextprotocol.io/v0/servers?search=sonilo
+
+If the schema has moved since this file was written, `mcp-publisher publish` will say so — regenerate with `mcp-publisher init` and re-apply the values from the committed `server.json`.
+
+### 3. Directories that need a one-off manual touch
+
+| Directory | Action | Time |
+|---|---|---|
+| [Glama](https://glama.ai/mcp/servers) | Syncs from the registry + crawls GitHub; after step 2, claim the server via "Claim" (GitHub sign-in) to control the listing | 2 min |
+| [Smithery](https://smithery.ai) | `smithery.yaml` is committed in this repo; sign in with GitHub on smithery.ai and add the repo | 3 min |
+| [PulseMCP](https://www.pulsemcp.com) | Hand-reviewed directory; submit via their "Submit a server" form | 2 min |
+| [mcp.so](https://mcp.so) | Submit via the site's Submit form (GitHub sign-in) | 2 min |
+
+### 4. When new versions ship
+
+`mcp-publisher publish` again with the bumped version in `server.json` (keep `packages[0].version` in sync with `pyproject.toml`). Consider wiring it into the release workflow — the registry repo documents a GitHub Actions setup (`docs/modelcontextprotocol-io/github-actions.mdx`).

--- a/server.json
+++ b/server.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.sonilo-ai/sonilo-mcp",
+  "title": "Sonilo Video-to-Music",
+  "description": "Generate an original, licensed soundtrack matched to your video. video_to_music watches the finished cut and composes music that follows its pacing and edits; text_to_music covers fixed-length tracks. Safe for commercial use (terms apply).",
+  "repository": {
+    "url": "https://github.com/sonilo-ai/sonilo-mcp",
+    "source": "github"
+  },
+  "version": "0.2.1",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "sonilo-mcp",
+      "version": "0.2.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "SONILO_API_KEY",
+          "description": "Sonilo API key from platform.sonilo.com/dashboard/api-keys",
+          "isRequired": true,
+          "format": "string",
+          "isSecret": true
+        },
+        {
+          "name": "SONILO_API_URL",
+          "description": "Public API base URL",
+          "isRequired": false,
+          "format": "string",
+          "default": "https://api.sonilo.com"
+        },
+        {
+          "name": "SONILO_MCP_BASE_PATH",
+          "description": "Default output directory and file-access confinement boundary",
+          "isRequired": false,
+          "format": "string",
+          "default": "~/Desktop"
+        },
+        {
+          "name": "TIME_OUT_SECONDS",
+          "description": "Generation timeout in seconds",
+          "isRequired": false,
+          "format": "number",
+          "default": "600"
+        }
+      ]
+    }
+  ]
+}

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.sonilo-ai/sonilo-mcp",
   "title": "Sonilo Video-to-Music",
-  "description": "Generate an original, licensed soundtrack matched to your video. video_to_music watches the finished cut and composes music that follows its pacing and edits; text_to_music covers fixed-length tracks. Safe for commercial use (terms apply).",
+  "description": "An original, licensed soundtrack matched to your video. Safe for commercial use (terms apply).",
   "repository": {
     "url": "https://github.com/sonilo-ai/sonilo-mcp",
     "source": "github"

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,29 @@
+# Smithery configuration — https://smithery.ai/docs/config
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    required:
+      - soniloApiKey
+    properties:
+      soniloApiKey:
+        type: string
+        description: Sonilo API key from platform.sonilo.com/dashboard/api-keys
+      soniloApiUrl:
+        type: string
+        default: https://api.sonilo.com
+        description: Public API base URL
+      timeoutSeconds:
+        type: number
+        default: 600
+        description: Generation timeout in seconds
+  commandFunction: |-
+    (config) => ({
+      command: 'uvx',
+      args: ['sonilo-mcp'],
+      env: {
+        SONILO_API_KEY: config.soniloApiKey,
+        SONILO_API_URL: config.soniloApiUrl || 'https://api.sonilo.com',
+        TIME_OUT_SECONDS: String(config.timeoutSeconds || 600)
+      }
+    })


### PR DESCRIPTION
Makes sonilo-mcp publishable to the official MCP Registry (registry.modelcontextprotocol.io) — currently sonilo-mcp is listed in ZERO MCP directories (checked: official registry, Glama 54k servers, mcp.so 19k, PulseMCP, Smithery, modelcontextprotocol/servers).

What this adds:

- `server.json` — registry metadata (io.github.sonilo-ai namespace, PyPI package, stdio transport, env vars). Version set to 0.2.1 — see sequencing below.
- README: hidden `mcp-name` comment — the registry verifies PyPI ownership by finding this marker in the package description on PyPI.
- `smithery.yaml` — Smithery directory config.
- `docs/PUBLISHING.md` — the exact one-time sequence + per-directory checklist.

**Sequencing (matters):** release 0.2.1 to PyPI first (so the published package carries the mcp-name marker), then `mcp-publisher login github && mcp-publisher publish` from an account in the sonilo-ai org. ~10 minutes total; PUBLISHING.md has copy-paste commands.

Why: the official registry is the machine-readable source that Glama, PulseMCP, and MCP clients sync from — one publish covers most of the discovery surface. The four remaining directories are 2-3 minute manual claims, listed in the guide.

— Cindy (context: the GitHub growth motion; Shawn assigned eng to the MCP asks 2026-07-11)