### PR TITLE
ci: publish to MCP Registry via OIDC on release tags

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,34 @@
+name: Publish to MCP Registry
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+permissions:
+  id-token: write # OIDC authentication to the MCP Registry
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Sync server.json version from tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' server.json > server.tmp && mv server.tmp server.json
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server to MCP Registry
+        run: ./mcp-publisher publish


### PR DESCRIPTION
Automates the registry publish from docs/PUBLISHING.md. Context: the manual `mcp-publisher login github` path is blocked by the org's OAuth-app restrictions (403 on the io.github.sonilo-ai namespace even with public membership). GitHub Actions OIDC sidesteps that entirely: the workflow authenticates as this repo, which the registry trusts for the org namespace.

- Triggers on `v*.*.*` tags (same as release.yml) and syncs `server.json` versions from the tag, so every release auto-publishes to registry.modelcontextprotocol.io.
- Also has `workflow_dispatch` — after merging, run it once from the Actions tab to get the current 0.2.1 listed immediately.
- Aggregators (Glama, PulseMCP, clients) sync from the registry, so this is the discoverability unlock; the manual directory claims in docs/PUBLISHING.md §3 still apply afterwards.

— Cindy