### PR TITLE
feat: audio ducking tool (v0.3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The `play_audio` tool requires PortAudio at runtime (for `sounddevice`). On macO
 - **macOS**: `brew install portaudio`
 - **Debian/Ubuntu**: `sudo apt-get install libportaudio2`
 
-`uvx sonilo-mcp` and `pip install` will pull the Python bindings, but the system PortAudio library must be installed separately. The other tools (`text_to_music`, `video_to_music`, `text_to_sfx`, `video_to_sfx`, `get_sfx_task`, `get_account_services`, `get_usage`) work without PortAudio.
+`uvx sonilo-mcp` and `pip install` will pull the Python bindings, but the system PortAudio library must be installed separately. The other tools (`text_to_music`, `video_to_music`, `text_to_sfx`, `video_to_sfx`, `audio_ducking`, `get_sfx_task`, `get_account_services`, `get_usage`) work without PortAudio.
 
 ## Quickstart with Claude Desktop
 
@@ -111,7 +111,7 @@ Once the server is connected, just ask your assistant in natural language. For e
 - *"Show my Sonilo usage for the last 7 days."*
 - *"Play the track you just generated."*
 
-The assistant will call the matching tool (`text_to_music`, `video_to_music`, `text_to_sfx`, `video_to_sfx`, `get_sfx_task`, `get_account_services`, `get_usage`, or `play_audio`) and save generated audio to your configured output directory.
+The assistant will call the matching tool (`text_to_music`, `video_to_music`, `text_to_sfx`, `video_to_sfx`, `audio_ducking`, `get_sfx_task`, `get_account_services`, `get_usage`, or `play_audio`) and save generated audio to your configured output directory.
 
 ## Configuration
 
@@ -142,18 +142,19 @@ files. To opt out — e.g. to read a video from elsewhere on disk — set
 | `video_to_music(video_path? \| video_url?, prompt?, output_directory?)` | Generate music matched to a video. Max duration **360s (6 min)**; subject to the account's upload-size cap (typically 300 MB). | ✅ |
 | `text_to_sfx(prompt, duration, audio_format?, output_directory?)` | Generate a sound effect from text. Duration 1–180s; formats wav/mp3/aac/flac (default aac). | ✅ |
 | `video_to_sfx(video_path? \| video_url?, prompt?, segments?, audio_format?, output_directory?)` | Generate SFX for a video; saves the SFX audio **and** the finished video with effects mixed in. Max video duration **180s (3 min)**. | ✅ |
-| `get_sfx_task(task_id, output_directory?)` | Check an SFX task and download its result — recovery for timed-out SFX calls. | ❌ |
+| `audio_ducking(voice_path? \| voice_url?, music_path? \| music_url?, output_directory?)` | Duck a music bed under a voice track. The voice input may be a video — the ducked mix is muxed back into a new `.mp4`. Each input max **360s (6 min)**; subject to the account's upload-size cap. | ✅ |
+| `get_sfx_task(task_id, output_directory?)` | Check an SFX or audio-ducking task and download its result — recovery for timed-out `text_to_sfx`, `video_to_sfx`, and `audio_ducking` calls. | ❌ |
 | `get_account_services()` | List available services and limits. | ❌ |
 | `get_usage(days=30)` | Show usage summary + per-day breakdown. | ❌ |
 | `play_audio(input_file_path)` | Play a local audio file. | ❌ |
 
 Tools marked ✅ make API calls that incur charges on your Sonilo account.
 
-> **Optional:** if [`ffprobe`](https://ffmpeg.org/) (part of FFmpeg) is installed, `video_to_music` checks a video's duration locally and rejects anything over 360s before uploading. `video_to_sfx` performs the same local check with its 180s cap. Without it, the same limits are still enforced by the backend.
+> **Optional:** if [`ffprobe`](https://ffmpeg.org/) (part of FFmpeg) is installed, `video_to_music` checks a video's duration locally and rejects anything over 360s before uploading. `video_to_sfx` performs the same local check with its 180s cap. `audio_ducking` does the same for both of its inputs against its 360s cap. Without it, the same limits are still enforced by the backend.
 
-### Sound effects run as tasks
+### Sound effects and ducking run as tasks
 
-The music tools stream their result and finish in one call. The SFX tools submit a *task*, then poll it until it completes — `text_to_sfx` and `video_to_sfx` do this for you and return the saved file paths, so you normally never see the task.
+The music tools stream their result and finish in one call. The SFX tools submit a *task*, then poll it until it completes — `text_to_sfx` and `video_to_sfx` do this for you and return the saved file paths, so you normally never see the task. `audio_ducking` uses the same submit-then-poll flow and the same `get_sfx_task` recovery path.
 
 If a call times out, the generation keeps running (and is already charged). The error message carries the task id, and `get_sfx_task("<id>")` retrieves the result once it's ready. The task id is also printed to stderr the moment a task is submitted, so it survives even a cancelled call. `get_sfx_task` is safe to call repeatedly: if the file is already on disk it reports that instead of downloading a second copy.
 
@@ -164,6 +165,8 @@ If a call times out, the generation keeps running (and is already charged). The 
 **Sound effects** are saved in the requested `audio_format` — `wav`, `mp3`, `flac`, or `aac` (the default, written as `.m4a`). `video_to_sfx` additionally saves the finished video as `.mp4` alongside the audio.
 
 File names come from the prompt (slugified, truncated to 80 characters). When there is no prompt to name a file after — `video_to_sfx` without one, or any file recovered via `get_sfx_task` — the name is `sfx-<first 8 chars of the task id>` instead. Existing files are never overwritten: a `-1`, `-2`, … suffix is added instead.
+
+**Ducking** results are saved as a single file: a `.wav`, or a `.mp4` when the voice input was a video (the ducked mix is muxed back into it). The file name is the voice input's name plus `-ducked` (e.g. `interview.mp4` → `interview-ducked.mp4`), falling back to `ducked-<first 8 chars of the task id>` when there is no usable name. A ducking result recovered via `get_sfx_task` is named `sfx-<first 8 chars of the task id>` instead, since that tool has no voice file name to work from.
 
 ## Common Errors
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sonilo-mcp"
-version = "0.2.1"
+version = "0.3.0"
 description = "MCP server for Sonilo AI music generation API"
 authors = [{ name = "Sonilo", email = "support@sonilo.com" }]
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/sonilo-ai/sonilo-mcp",
     "source": "github"
   },
-  "version": "0.2.1",
+  "version": "0.3.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "sonilo-mcp",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/sonilo_mcp/api.py
+++ b/src/sonilo_mcp/api.py
@@ -733,6 +733,42 @@ def _ext_from_content_type(content_type: str | None) -> str:
     return _AUDIO_CONTENT_TYPE_EXTS.get(content_type.lower(), ".m4a")
 
 
+# Ducking renders wav, and re-muxes into mp4 when the voice input was a
+# video. Its envelope carries no content_type, so the type is fixed here
+# from output_type — these strings feed _ext_from_content_type, so
+# "audio/wav" must stay a key of _AUDIO_CONTENT_TYPE_EXTS.
+_DUCKING_CONTENT_TYPES = {"audio": "audio/wav", "video": "video/mp4"}
+
+
+def _normalize_task_envelope(body: dict) -> dict:
+    """Rewrite audio-ducking's flat success envelope into the SFX shape.
+
+    SFX tasks return `{"audio": {...}, "video": {...}}`; audio-ducking
+    returns `{"output_url": ..., "output_type": "audio" | "video"}` — one
+    artifact, never both. Normalizing here means _save_task_artifacts and
+    everything under it (extension, reuse check, atomic name reservation,
+    download, recovery wording) stays single-path.
+
+    A video output is the ONLY artifact of that task: the ducked audio is
+    inside the re-muxed mp4, so no audio slot is produced — see
+    _save_task_artifacts, which requires at least one artifact rather than
+    an audio one specifically.
+
+    Returns `body` unchanged when there is no usable `output_url` (every
+    SFX body, and any malformed ducking body — which then falls through to
+    _save_task_artifacts' missing-artifact error, task_id and all). Never
+    mutates the caller's dict.
+    """
+    url = body.get("output_url")
+    if not isinstance(url, str) or not url:
+        return body
+    output_type = body.get("output_type")
+    slot = "video" if output_type == "video" else "audio"
+    normalized = dict(body)
+    normalized[slot] = {"url": url, "content_type": _DUCKING_CONTENT_TYPES[slot]}
+    return normalized
+
+
 _ARTIFACT_DEST_MAX_ATTEMPTS = 10_000
 
 
@@ -860,8 +896,11 @@ async def _save_task_artifacts(
     """Turn a terminal /v1/tasks/{id} body into saved local files.
 
     failed -> raise with the backend's error code/message and whether the
-    charge was refunded. succeeded -> download audio (always present) and
-    video (video-to-sfx only), one TextContent per saved file.
+    charge was refunded. succeeded -> download whichever artifacts the task
+    produced — audio and/or video — one TextContent per saved file. At least
+    one artifact is required; an SFX task always has audio (plus video for
+    video-to-sfx), while an audio-ducking task with a video voice input has
+    only the re-muxed mp4 (see _normalize_task_envelope).
 
     task_id must be the caller's own known-good id (from _post_task_submit
     or the tool's own task_id argument), NOT derived from body — the
@@ -917,12 +956,20 @@ async def _save_task_artifacts(
             f'get_sfx_task("{task_id}").'
         )
 
+    body = _normalize_task_envelope(body)
+
+    def _has_artifact(slot: object) -> bool:
+        return isinstance(slot, dict) and bool(slot.get("url"))
+
     audio = body.get("audio")
-    if not isinstance(audio, dict) or not audio.get("url"):
+    video = body.get("video")
+    if not _has_artifact(audio) and not _has_artifact(video):
         # The backend already succeeded and charged for this task — a
-        # missing/malformed audio envelope must still carry the task_id and
-        # the get_sfx_task recovery call, or a paid result becomes
-        # unrecoverable from the error message alone.
+        # missing/malformed envelope must still carry the task_id and the
+        # get_sfx_task recovery call, or a paid result becomes unrecoverable
+        # from the error message alone. "At least one" rather than "audio":
+        # a ducking task with a video voice input renders exactly one
+        # artifact, the re-muxed mp4, and has no audio slot at all.
         raise Exception(
             "Task succeeded but no audio artifact was returned. Task id: "
             f'{task_id} — call get_sfx_task("{task_id}") to check for the '
@@ -930,44 +977,52 @@ async def _save_task_artifacts(
         )
 
     saved: list[TextContent] = []
-    try:
-        # Everything below — deriving the extension, checking for a
-        # reusable existing file, computing the destination path, and the
-        # actual download — must stay inside this wrap. The backend already
-        # succeeded and charged for this task by the time we get here, so
-        # ANY failure here must still carry the task_id and recovery hint.
-        # _download_artifact (and any other failure here, e.g. an OSError
-        # from _artifact_dest) states only the bare fact of the failure —
-        # this is the one layer that owns the single, complete recovery
-        # instruction, so it isn't repeated.
-        audio_ext = _ext_from_content_type(audio.get("content_type"))
-        existing = (
-            _existing_canonical_dest(
-                output_path, base_name, audio_ext, audio.get("file_size")
+    # Stays None for a video-only ducking result, where no audio artifact
+    # exists — the video block's failure message keys off this so it never
+    # claims an audio file was saved when none was.
+    audio_dest: Path | None = None
+    if _has_artifact(audio):
+        try:
+            # Everything below — deriving the extension, checking for a
+            # reusable existing file, computing the destination path, and the
+            # actual download — must stay inside this wrap. The backend already
+            # succeeded and charged for this task by the time we get here, so
+            # ANY failure here must still carry the task_id and recovery hint.
+            # _download_artifact (and any other failure here, e.g. an OSError
+            # from _artifact_dest) states only the bare fact of the failure —
+            # this is the one layer that owns the single, complete recovery
+            # instruction, so it isn't repeated.
+            audio_ext = _ext_from_content_type(audio.get("content_type"))
+            existing = (
+                _existing_canonical_dest(
+                    output_path, base_name, audio_ext, audio.get("file_size")
+                )
+                if reuse_existing
+                else None
             )
-            if reuse_existing
-            else None
-        )
-        if existing is None:
-            dest = _artifact_dest(output_path, base_name, audio_ext)
-            await _download_artifact(audio["url"], dest)
+            if existing is None:
+                dest = _artifact_dest(output_path, base_name, audio_ext)
+                await _download_artifact(audio["url"], dest)
+            else:
+                dest = existing
+        except Exception as e:
+            raise Exception(
+                f"{_end_sentence(e)} The result is still stored on the backend "
+                f'— call get_sfx_task("{task_id}") to retry.'
+            ) from e
+        if existing is not None:
+            saved.append(
+                TextContent(
+                    type="text", text=f"Already downloaded. File saved as: {dest}"
+                )
+            )
         else:
-            dest = existing
-    except Exception as e:
-        raise Exception(
-            f"{_end_sentence(e)} The result is still stored on the backend "
-            f'— call get_sfx_task("{task_id}") to retry.'
-        ) from e
-    if existing is not None:
-        saved.append(
-            TextContent(type="text", text=f"Already downloaded. File saved as: {dest}")
-        )
-    else:
-        saved.append(TextContent(type="text", text=f"Success. File saved as: {dest}"))
-    audio_dest = dest
+            saved.append(
+                TextContent(type="text", text=f"Success. File saved as: {dest}")
+            )
+        audio_dest = dest
 
-    video = body.get("video")
-    if isinstance(video, dict) and video.get("url"):
+    if _has_artifact(video):
         try:
             existing_video = (
                 _existing_canonical_dest(
@@ -982,10 +1037,15 @@ async def _save_task_artifacts(
             else:
                 dest = existing_video
         except Exception as e:
+            if audio_dest is not None:
+                raise Exception(
+                    f"{_end_sentence(e)} The audio file was already saved as: "
+                    f"{audio_dest}. The video is still stored on the backend — "
+                    f'call get_sfx_task("{task_id}") to retry the download.'
+                ) from e
             raise Exception(
-                f"{_end_sentence(e)} The audio file was already saved as: "
-                f"{audio_dest}. The video is still stored on the backend — "
-                f'call get_sfx_task("{task_id}") to retry the download.'
+                f"{_end_sentence(e)} The result is still stored on the backend "
+                f'— call get_sfx_task("{task_id}") to retry.'
             ) from e
         if existing_video is not None:
             saved.append(

--- a/src/sonilo_mcp/api.py
+++ b/src/sonilo_mcp/api.py
@@ -740,8 +740,11 @@ def _ext_from_content_type(content_type: str | None) -> str:
 _DUCKING_CONTENT_TYPES = {"audio": "audio/wav", "video": "video/mp4"}
 
 
-def _normalize_task_envelope(body: dict) -> dict:
+def _normalize_task_envelope(body: dict) -> tuple[dict, bool]:
     """Rewrite audio-ducking's flat success envelope into the SFX shape.
+
+    Returns `(body, is_ducking)`, where `is_ducking` says whether a ducking
+    envelope was actually recognized and normalized.
 
     SFX tasks return `{"audio": {...}, "video": {...}}`; audio-ducking
     returns `{"output_url": ..., "output_type": "audio" | "video"}` — one
@@ -750,23 +753,26 @@ def _normalize_task_envelope(body: dict) -> dict:
     download, recovery wording) stays single-path.
 
     A video output is the ONLY artifact of that task: the ducked audio is
-    inside the re-muxed mp4, so no audio slot is produced — see
-    _save_task_artifacts, which requires at least one artifact rather than
-    an audio one specifically.
+    inside the re-muxed mp4, so no audio slot is produced. The `is_ducking`
+    flag is what lets _save_task_artifacts allow that video-only case
+    WITHOUT weakening the audio requirement for SFX bodies (where a missing
+    audio slot means half a paid result went missing) — it is reported from
+    here, the one place that knows which envelope it saw, rather than
+    re-sniffed downstream.
 
-    Returns `body` unchanged when there is no usable `output_url` (every
-    SFX body, and any malformed ducking body — which then falls through to
-    _save_task_artifacts' missing-artifact error, task_id and all). Never
-    mutates the caller's dict.
+    Returns `(body, False)` when there is no usable `output_url` — every SFX
+    body, and any malformed ducking body, which is then held to the SFX
+    contract and falls through to _save_task_artifacts' missing-artifact
+    error, task_id and all. Never mutates the caller's dict.
     """
     url = body.get("output_url")
     if not isinstance(url, str) or not url:
-        return body
+        return body, False
     output_type = body.get("output_type")
     slot = "video" if output_type == "video" else "audio"
     normalized = dict(body)
     normalized[slot] = {"url": url, "content_type": _DUCKING_CONTENT_TYPES[slot]}
-    return normalized
+    return normalized, True
 
 
 _ARTIFACT_DEST_MAX_ATTEMPTS = 10_000
@@ -897,10 +903,11 @@ async def _save_task_artifacts(
 
     failed -> raise with the backend's error code/message and whether the
     charge was refunded. succeeded -> download whichever artifacts the task
-    produced — audio and/or video — one TextContent per saved file. At least
-    one artifact is required; an SFX task always has audio (plus video for
-    video-to-sfx), while an audio-ducking task with a video voice input has
-    only the re-muxed mp4 (see _normalize_task_envelope).
+    produced — audio and/or video — one TextContent per saved file. An audio
+    artifact is required: an SFX task always has audio (plus video for
+    video-to-sfx). The sole exemption is an audio-ducking task with a video
+    voice input, whose only artifact is the re-muxed mp4 (see
+    _normalize_task_envelope, which reports whether it saw that envelope).
 
     task_id must be the caller's own known-good id (from _post_task_submit
     or the tool's own task_id argument), NOT derived from body — the
@@ -956,20 +963,25 @@ async def _save_task_artifacts(
             f'get_sfx_task("{task_id}").'
         )
 
-    body = _normalize_task_envelope(body)
+    body, is_ducking = _normalize_task_envelope(body)
 
     def _has_artifact(slot: object) -> bool:
         return isinstance(slot, dict) and bool(slot.get("url"))
 
     audio = body.get("audio")
     video = body.get("video")
-    if not _has_artifact(audio) and not _has_artifact(video):
-        # The backend already succeeded and charged for this task — a
-        # missing/malformed envelope must still carry the task_id and the
-        # get_sfx_task recovery call, or a paid result becomes unrecoverable
-        # from the error message alone. "At least one" rather than "audio":
-        # a ducking task with a video voice input renders exactly one
-        # artifact, the re-muxed mp4, and has no audio slot at all.
+    # An audio artifact is required, with exactly one exemption: a ducking
+    # task whose voice input was a video renders a single artifact, the
+    # re-muxed mp4, and has no audio slot at all. The exemption is keyed off
+    # _normalize_task_envelope having recognized a ducking envelope — NOT off
+    # "some artifact is present". An SFX body is still held to the audio
+    # requirement even when it carries a video: a video-without-audio SFX
+    # result means the audio half of an already-charged generation went
+    # missing, and quietly downloading just the mp4 would report success
+    # while losing it, with no recovery hint. Raising here keeps the task_id
+    # and the get_sfx_task call in the user's hands, which is the only way a
+    # paid result stays recoverable from the error message alone.
+    if not _has_artifact(audio) and not (is_ducking and _has_artifact(video)):
         raise Exception(
             "Task succeeded but no audio artifact was returned. Task id: "
             f'{task_id} — call get_sfx_task("{task_id}") to check for the '

--- a/src/sonilo_mcp/api.py
+++ b/src/sonilo_mcp/api.py
@@ -1397,20 +1397,21 @@ async def video_to_sfx(
 
 @mcp.tool(
     description=(
-        "Check a sound-effects generation task and, if finished, download "
-        "its result file(s). Use this to recover a result when text_to_sfx "
-        "or video_to_sfx timed out — their error message contains the "
-        "task_id. Does not poll: a single status check per call. This tool "
-        "itself never charges.\n\n"
+        "Check a sound-effects or audio-ducking generation task and, if "
+        "finished, download its result file(s). Use this to recover a "
+        "result when text_to_sfx, video_to_sfx, or audio_ducking timed out "
+        "— their error message contains the task_id. Does not poll: a "
+        "single status check per call. This tool itself never charges.\n\n"
         "Args:\n"
         "    task_id (str): The task id returned in the timeout message.\n"
         "    output_directory (str, optional): Where to save result files. "
         "Defaults to SONILO_MCP_BASE_PATH.\n\n"
         "Returns:\n"
         "    Still processing -> a status message; try again later. "
-        "Succeeded -> the saved file path(s) (audio, plus video for "
-        "video_to_sfx tasks). Failed -> an error including whether the "
-        "charge was refunded."
+        "Succeeded -> the saved file path(s): audio, plus video for "
+        "video_to_sfx tasks; a single .wav or .mp4 for audio_ducking "
+        "tasks. Failed -> an error including whether the charge was "
+        "refunded."
     )
 )
 async def get_sfx_task(

--- a/src/sonilo_mcp/api.py
+++ b/src/sonilo_mcp/api.py
@@ -305,7 +305,11 @@ async def _check_media_duration(
             stderr=asyncio.subprocess.PIPE,
         )
         stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=30)
-    except (asyncio.TimeoutError, OSError):
+    except (asyncio.TimeoutError, OSError, ValueError):
+        # ValueError: create_subprocess_exec rejects a source containing an
+        # embedded NUL byte (or similar odd chars) before spawning. This
+        # helper is best-effort, so fail open and let the backend decide
+        # rather than crash the whole request with a raw traceback.
         return  # fail open — let the backend decide
     if proc.returncode != 0:
         return
@@ -1068,6 +1072,22 @@ async def _save_task_artifacts(
     # and the get_sfx_task call in the user's hands, which is the only way a
     # paid result stays recoverable from the error message alone.
     if not _has_artifact(audio) and not (is_ducking and _has_artifact(video)):
+        # Distinguish an unrecognized-output_type ducking result from a genuine
+        # missing artifact. When there is a usable output_url but the
+        # output_type is not one _normalize_task_envelope handles, get_sfx_task
+        # would re-run the same normalization and produce this identical error
+        # forever — so instead of the (useless) recovery hint, surface the
+        # output_url and output_type so the user can fetch the paid result
+        # manually. The genuine no-artifact case (no usable output_url) keeps
+        # the original message unchanged.
+        url = body.get("output_url")
+        if isinstance(url, str) and url:
+            slot = body.get("output_type")
+            raise Exception(
+                f"Task succeeded but its output_type {slot!r} is not "
+                "recognized, so the result could not be saved automatically. "
+                f"Download it directly from: {url}. Task id: {task_id}."
+            )
         raise Exception(
             "Task succeeded but no audio artifact was returned. Task id: "
             f'{task_id} — call get_sfx_task("{task_id}") to check for the '

--- a/src/sonilo_mcp/api.py
+++ b/src/sonilo_mcp/api.py
@@ -237,6 +237,7 @@ def _resolve_input_file(
 # fast and skip a wasted upload. Keep in sync with the backend's limit.
 _MAX_VIDEO_DURATION_SECONDS = 360  # 6 minutes — music endpoints
 _SFX_MAX_VIDEO_DURATION_SECONDS = 180  # 3 minutes — /v1/video-to-sfx
+_DUCKING_MAX_DURATION_SECONDS = 360  # 6 minutes — /v1/audio-ducking, per input
 
 
 async def _check_media_duration(
@@ -1487,6 +1488,181 @@ async def get_sfx_task(
     return await _save_task_artifacts(
         body, out_path, f"sfx-{task_id[:8]}", task_id, reuse_existing=True
     )
+
+
+# ---------- Tools: audio ducking ----------
+
+
+def _require_exactly_one(path: str | None, url: str | None, label: str) -> None:
+    """Exactly-one-of check for a ducking input pair.
+
+    Called for BOTH inputs before any I/O, mirroring the backend's
+    _validate_presence: a missing music input must be reported even when the
+    voice input is what would have failed to resolve.
+    """
+    if path and url:
+        raise Exception(
+            f"Provide either {label}_path or {label}_url (exactly one, not both)"
+        )
+    if not path and not url:
+        raise Exception(f"Provide either {label}_path or {label}_url")
+
+
+def _require_http_url(url: str, label: str) -> None:
+    """Restrict a caller-supplied URL to http(s) before it reaches ffprobe or
+    the backend — keeps file:// (local file disclosure), internal addresses
+    (SSRF from this machine), and "-"-prefixed values (ffprobe flag injection)
+    out. Same guard as video_to_music.
+    """
+    if urlparse(url).scheme.lower() not in ("http", "https"):
+        raise Exception(f"{label}_url must be an http:// or https:// URL")
+
+
+def _read_capped(path: Path, max_mb: int, label: str) -> bytes:
+    """Read a file for upload, enforcing the account's size cap on the bytes
+    actually read.
+
+    An earlier stat() is stale by the time we get here (an await on ffprobe
+    sat in between, during which the file could have been replaced or grown —
+    a still-writing export, a sync tool). Reading at most max_bytes + 1 both
+    closes that race and bounds memory use.
+    """
+    max_bytes = max_mb * 1024 * 1024
+    with open(path, "rb") as fh:
+        content = fh.read(max_bytes + 1)
+    if len(content) > max_bytes:
+        raise Exception(f"{label} file is too large (> {max_mb} MB cap)")
+    return content
+
+
+@mcp.tool(
+    description=(
+        "Duck a music bed under a voice track: Sonilo lowers the music "
+        "wherever the voice is speaking and lifts it back in the gaps, then "
+        "returns the mixed result. The voice input may be a video — its "
+        "audio track is used as the voice, and the ducked mix is muxed back "
+        "into a new video.\n\n"
+        "⚠️ COST WARNING: This tool makes an API call to Sonilo which may "
+        "incur charges. Only use when explicitly requested by the user.\n\n"
+        "Args:\n"
+        "    voice_path (str, optional): Absolute local path, or relative to "
+        "SONILO_MCP_BASE_PATH. Audio (.wav/.mp3/.m4a/.aac/.ogg/.flac) or "
+        "video (.mp4/.mov/.avi/.wmv/.webm/.mkv).\n"
+        "    voice_url (str, optional): HTTPS URL to the voice audio/video.\n"
+        "    music_path (str, optional): Absolute local path, or relative to "
+        "SONILO_MCP_BASE_PATH. Audio only.\n"
+        "    music_url (str, optional): HTTPS URL to the music audio.\n"
+        "    output_directory (str, optional): Where to save the result. "
+        "Defaults to SONILO_MCP_BASE_PATH.\n\n"
+        "Exactly one of voice_path/voice_url, and exactly one of "
+        "music_path/music_url, must be provided. A local file and a URL may "
+        "be mixed across the two inputs. Each input is capped at 360 seconds "
+        "(6 minutes) and by the account's upload-size limit (typically "
+        "300 MB).\n\n"
+        "Returns:\n"
+        "    TextContent with the absolute path of the saved file: a .wav, "
+        "or a .mp4 when the voice input was a video. If the call times out, "
+        "the error message includes the task_id — recover the result later "
+        "with get_sfx_task."
+    )
+)
+async def audio_ducking(
+    voice_path: str | None = None,
+    voice_url: str | None = None,
+    music_path: str | None = None,
+    music_url: str | None = None,
+    output_directory: str | None = None,
+) -> list[TextContent]:
+    # Both pairs are validated before any I/O — see _require_exactly_one.
+    _require_exactly_one(voice_path, voice_url, "voice")
+    _require_exactly_one(music_path, music_url, "music")
+    if voice_url:
+        _require_http_url(voice_url, "voice")
+    if music_url:
+        _require_http_url(music_url, "music")
+
+    out_path = _make_output_path(output_directory)
+    cfg = _get_config()
+
+    # Resolve local inputs (existence + extension + base-path confinement)
+    # before anything hits the network: a bad path is a caller error and
+    # should not cost an /v1/account/services round trip.
+    #
+    # A voice input may be audio OR video: the backend extracts a video's
+    # audio track and re-muxes the ducked result back into it. Music is audio
+    # only — the backend never probes it for a video stream, so a video there
+    # would be silently mishandled.
+    voice_file = (
+        _resolve_input_file(
+            voice_path,
+            cfg["base_path"],
+            _AUDIO_EXTS | _VIDEO_EXTS,
+            "audio or video",
+        )
+        if voice_path
+        else None
+    )
+    music_file = (
+        _resolve_input_file(music_path, cfg["base_path"], _AUDIO_EXTS, "audio")
+        if music_path
+        else None
+    )
+
+    data: dict = {}
+    files: dict = {}
+    max_mb = await _get_max_upload_size_mb() if (voice_file or music_file) else 0
+
+    if voice_file is not None:
+        size_mb = voice_file.stat().st_size / (1024 * 1024)
+        if size_mb > max_mb:
+            # Cheap fail-fast before a wasted ffprobe run. NOT authoritative —
+            # see _read_capped.
+            raise Exception(
+                f"Voice file is too large ({size_mb:.1f} MB > {max_mb} MB cap)"
+            )
+        await _check_media_duration(
+            str(voice_file), max_seconds=_DUCKING_MAX_DURATION_SECONDS
+        )
+        mime, _ = mimetypes.guess_type(voice_file.name)
+        files["voice_file"] = (
+            voice_file.name,
+            _read_capped(voice_file, max_mb, "Voice"),
+            mime or "application/octet-stream",
+        )
+    else:
+        await _check_media_duration(
+            voice_url, max_seconds=_DUCKING_MAX_DURATION_SECONDS
+        )
+        data["voice_url"] = voice_url
+
+    if music_file is not None:
+        size_mb = music_file.stat().st_size / (1024 * 1024)
+        if size_mb > max_mb:
+            raise Exception(
+                f"Music file is too large ({size_mb:.1f} MB > {max_mb} MB cap)"
+            )
+        await _check_media_duration(
+            str(music_file), max_seconds=_DUCKING_MAX_DURATION_SECONDS
+        )
+        mime, _ = mimetypes.guess_type(music_file.name)
+        files["music_file"] = (
+            music_file.name,
+            _read_capped(music_file, max_mb, "Music"),
+            mime or "application/octet-stream",
+        )
+    else:
+        await _check_media_duration(
+            music_url, max_seconds=_DUCKING_MAX_DURATION_SECONDS
+        )
+        data["music_url"] = music_url
+
+    # Everything below this line can charge the user: no validation past here.
+    task_id = await _post_task_submit(
+        "/v1/audio-ducking", data=data or None, files=files or None
+    )
+    body = await _poll_task(task_id, cfg["timeout"])
+    base = _ducking_base_name(voice_path, voice_url, task_id)
+    return await _save_task_artifacts(body, out_path, base, task_id)
 
 
 # ---------- Tools: account ----------

--- a/src/sonilo_mcp/api.py
+++ b/src/sonilo_mcp/api.py
@@ -213,13 +213,17 @@ _MAX_VIDEO_DURATION_SECONDS = 360  # 6 minutes — music endpoints
 _SFX_MAX_VIDEO_DURATION_SECONDS = 180  # 3 minutes — /v1/video-to-sfx
 
 
-async def _check_video_duration(
+async def _check_media_duration(
     source: str, max_seconds: int = _MAX_VIDEO_DURATION_SECONDS
 ) -> None:
-    """Best-effort local ffprobe pre-check of a video's duration.
+    """Best-effort local ffprobe pre-check of a media file's duration.
+
+    Reads `format.duration`, which ffprobe reports for audio files as well
+    as videos — so this serves the video endpoints and the audio-ducking
+    endpoint alike.
 
     Raises if the duration is known to exceed `max_seconds`, so the caller
-    fails fast instead of uploading a video the backend will reject.
+    fails fast instead of uploading media the backend will reject.
     `source` may be a local path or a URL (ffprobe handles both).
 
     The check is best-effort: if ffprobe is not installed, times out, or
@@ -1127,7 +1131,7 @@ async def video_to_music(
             raise Exception(
                 f"Video file is too large ({size_mb:.1f} MB > {max_mb} MB cap)"
             )
-        await _check_video_duration(str(resolved))
+        await _check_media_duration(str(resolved))
         data = {"prompt": prompt} if prompt else None
         mime, _ = mimetypes.guess_type(resolved.name)
         # Authoritative check: the stat() above is now stale — an await on
@@ -1150,7 +1154,7 @@ async def video_to_music(
         )
 
     # video_url path — backend expects multipart form, not JSON
-    await _check_video_duration(video_url)
+    await _check_media_duration(video_url)
     form: dict = {"video_url": video_url}
     if prompt:
         form["prompt"] = prompt
@@ -1285,7 +1289,7 @@ async def video_to_sfx(
             raise Exception(
                 f"Video file is too large ({size_mb:.1f} MB > {max_mb} MB cap)"
             )
-        await _check_video_duration(
+        await _check_media_duration(
             str(resolved), max_seconds=_SFX_MAX_VIDEO_DURATION_SECONDS
         )
         mime, _ = mimetypes.guess_type(resolved.name)
@@ -1308,7 +1312,7 @@ async def video_to_sfx(
             "/v1/video-to-sfx", data=form or None, files=files
         )
     else:
-        await _check_video_duration(
+        await _check_media_duration(
             video_url, max_seconds=_SFX_MAX_VIDEO_DURATION_SECONDS
         )
         form["video_url"] = video_url

--- a/src/sonilo_mcp/api.py
+++ b/src/sonilo_mcp/api.py
@@ -168,6 +168,32 @@ def _slugify(text: str) -> str:
     return safe or "sonilo"
 
 
+def _ducking_base_name(
+    voice_path: str | None, voice_url: str | None, task_id: str
+) -> str:
+    """Name a ducking result after its voice input: interview.mp4 ->
+    interview-ducked(.mp4).
+
+    The voice track is what the user recognizes — the music bed is
+    interchangeable — so it is the half worth naming the output after. For
+    a URL, the last path segment is used (query and fragment are dropped by
+    urlparse). When neither input yields a usable stem, fall back to
+    ducked-{task_id[:8]}, mirroring get_sfx_task's sfx-{task_id[:8]}.
+
+    The extension is NOT decided here: it comes from the task envelope
+    (.wav, or .mp4 when the voice input was a video) — see
+    _normalize_task_envelope.
+    """
+    raw = ""
+    if voice_path:
+        raw = Path(os.path.expanduser(voice_path)).stem
+    elif voice_url:
+        raw = Path(urlparse(voice_url).path).stem
+    if not raw.strip():
+        return f"ducked-{task_id[:8]}"
+    return f"{_slugify(raw)}-ducked"
+
+
 _AUDIO_EXTS = frozenset({".wav", ".mp3", ".m4a", ".aac", ".ogg", ".flac"})
 _VIDEO_EXTS = frozenset({".mp4", ".mov", ".avi", ".wmv", ".webm", ".mkv"})
 

--- a/src/sonilo_mcp/api.py
+++ b/src/sonilo_mcp/api.py
@@ -233,6 +233,41 @@ def _resolve_input_file(
     return path
 
 
+def _require_http_url(url: str, label: str) -> None:
+    """Restrict a caller-supplied URL to http(s) before it reaches ffprobe or
+    the backend — keeps file:// (local file disclosure), internal addresses
+    (SSRF from this machine), and "-"-prefixed values (ffprobe flag injection)
+    out.
+
+    `label` names the offending argument (e.g. "video" -> "video_url must be
+    an http:// or https:// URL"). The single copy of this guard: every tool
+    that accepts a URL (video_to_music, video_to_sfx, audio_ducking) calls it.
+    """
+    if urlparse(url).scheme.lower() not in ("http", "https"):
+        raise Exception(f"{label}_url must be an http:// or https:// URL")
+
+
+def _read_capped(path: Path, max_mb: int, label: str) -> bytes:
+    """Read a file for upload, enforcing the account's size cap on the bytes
+    actually read.
+
+    An earlier stat() is stale by the time we get here (an await on ffprobe
+    sat in between, during which the file could have been replaced or grown —
+    a still-writing export, a sync tool). Reading at most max_bytes + 1 both
+    closes that race and bounds memory use.
+
+    `label` names the input in the error message (e.g. "Video", "Voice",
+    "Music"). The single copy of the read-time cap: every tool that uploads a
+    local file calls it.
+    """
+    max_bytes = max_mb * 1024 * 1024
+    with open(path, "rb") as fh:
+        content = fh.read(max_bytes + 1)
+    if len(content) > max_bytes:
+        raise Exception(f"{label} file is too large (> {max_mb} MB cap)")
+    return content
+
+
 # The backend rejects videos longer than this, so we pre-check locally to fail
 # fast and skip a wasted upload. Keep in sync with the backend's limit.
 _MAX_VIDEO_DURATION_SECONDS = 360  # 6 minutes — music endpoints
@@ -280,7 +315,7 @@ async def _check_media_duration(
         return
     if duration > max_seconds:
         raise Exception(
-            f"Video duration {duration:.1f}s exceeds the maximum of "
+            f"Media duration {duration:.1f}s exceeds the maximum of "
             f"{max_seconds}s"
         )
 
@@ -377,8 +412,10 @@ def _is_task_not_found(e: BaseException) -> bool:
     """Whether `e` means the task_id itself is gone/invalid — the only case
     where recovery advice should be omitted.
 
-    Only a 404 means that: a bad/typo'd id, or a non-SFX (e.g. music) task
-    id — /v1/tasks is SFX-only and 404s those. Every OTHER error (401, 402,
+    Only a 404 means that: a bad/typo'd id, or an id for a task type
+    /v1/tasks does not serve. It serves SFX and audio-ducking tasks; a
+    streaming (e.g. music) generation has no task at all, so its id 404s
+    here. Every OTHER error (401, 402,
     413, 422, 429, 5xx, or a network-level failure with no status at all,
     e.g. httpx.RequestError wrapped as a bare Exception by _http_get_json)
     still refers to a task that EXISTS and was already CHARGED — the cause
@@ -761,9 +798,17 @@ def _ext_from_content_type(content_type: str | None) -> str:
 
 
 # Ducking renders wav, and re-muxes into mp4 when the voice input was a
-# video. Its envelope carries no content_type, so the type is fixed here
-# from output_type — these strings feed _ext_from_content_type, so
-# "audio/wav" must stay a key of _AUDIO_CONTENT_TYPE_EXTS.
+# video. Its envelope carries no content_type, so the type is synthesized
+# here from output_type. Only the "audio" value is ever read back:
+# _save_task_artifacts derives the audio extension from it via
+# _ext_from_content_type, so "audio/wav" must stay a key of
+# _AUDIO_CONTENT_TYPE_EXTS. The video branch hard-codes ".mp4" and never
+# looks at content_type — the "video/mp4" entry is carried only so the
+# normalized slot is shaped like an SFX one.
+#
+# This dict is also the authoritative set of output_type values: an
+# output_type outside these keys is NOT a ducking envelope (see
+# _normalize_task_envelope).
 _DUCKING_CONTENT_TYPES = {"audio": "audio/wav", "video": "video/mp4"}
 
 
@@ -787,19 +832,36 @@ def _normalize_task_envelope(body: dict) -> tuple[dict, bool]:
     here, the one place that knows which envelope it saw, rather than
     re-sniffed downstream.
 
-    Returns `(body, False)` when there is no usable `output_url` — every SFX
+    Returns `(body, False)` when there is no usable `output_url`, or when
+    `output_type` is anything other than "audio" or "video" — every SFX
     body, and any malformed ducking body, which is then held to the SFX
     contract and falls through to _save_task_artifacts' missing-artifact
     error, task_id and all. Never mutates the caller's dict.
+
+    output_type is matched STRICTLY (no defaulting to "audio"): a missing or
+    unrecognized type alongside a valid output_url would otherwise be
+    downloaded and written with a fabricated .wav extension and reported as a
+    success — a paid result silently mislabeled. Refusing it here routes the
+    body to the charged-and-recoverable error path instead, which hands the
+    caller the task_id and the get_sfx_task hint; the artifact is still on
+    the backend, so nothing is lost.
     """
     url = body.get("output_url")
     if not isinstance(url, str) or not url:
         return body, False
-    output_type = body.get("output_type")
-    slot = "video" if output_type == "video" else "audio"
+    slot = body.get("output_type")
+    # isinstance first: a non-string (an unhashable list/dict from a backend
+    # bug) would make the membership test raise instead of falling through.
+    if not isinstance(slot, str) or slot not in _DUCKING_CONTENT_TYPES:
+        return body, False
     normalized = dict(body)
     normalized[slot] = {"url": url, "content_type": _DUCKING_CONTENT_TYPES[slot]}
     return normalized, True
+
+
+def _has_artifact(slot: object) -> bool:
+    """Whether a task envelope's audio/video slot actually carries a URL."""
+    return isinstance(slot, dict) and bool(slot.get("url"))
 
 
 _ARTIFACT_DEST_MAX_ATTEMPTS = 10_000
@@ -991,9 +1053,6 @@ async def _save_task_artifacts(
         )
 
     body, is_ducking = _normalize_task_envelope(body)
-
-    def _has_artifact(slot: object) -> bool:
-        return isinstance(slot, dict) and bool(slot.get("url"))
 
     audio = body.get("audio")
     video = body.get("video")
@@ -1206,13 +1265,8 @@ async def video_to_music(
 
     if video_url:
         # Restrict to http(s) before the URL ever reaches the local ffprobe
-        # pre-check or the backend. Without this, a caller (e.g. via prompt
-        # injection) could pass file:// to probe local files, an internal
-        # address to trigger SSRF from this machine, or a "-"-prefixed value
-        # to inject ffprobe flags.
-        scheme = urlparse(video_url).scheme.lower()
-        if scheme not in ("http", "https"):
-            raise Exception("video_url must be an http:// or https:// URL")
+        # pre-check or the backend (see _require_http_url).
+        _require_http_url(video_url, "video")
 
     out_path = _make_output_path(output_directory)
     cfg = _get_config()
@@ -1226,24 +1280,14 @@ async def video_to_music(
         if size_mb > max_mb:
             # Cheap fail-fast: avoids a wasted ffprobe run for an
             # obviously-oversized file. NOT the authoritative check — see
-            # the read-time check below.
+            # _read_capped, which enforces the cap on the bytes actually read.
             raise Exception(
                 f"Video file is too large ({size_mb:.1f} MB > {max_mb} MB cap)"
             )
         await _check_media_duration(str(resolved))
         data = {"prompt": prompt} if prompt else None
         mime, _ = mimetypes.guess_type(resolved.name)
-        # Authoritative check: the stat() above is now stale — an await on
-        # ffprobe sat between it and this read, during which the file could
-        # have been replaced or grown (a video export still writing, a sync
-        # tool, a concurrent process). Enforce the cap on the bytes actually
-        # read for upload, not on the earlier stat(). Reading at most
-        # max_bytes + 1 both closes that race and bounds memory use.
-        max_bytes = max_mb * 1024 * 1024
-        with open(resolved, "rb") as fh:
-            content = fh.read(max_bytes + 1)
-        if len(content) > max_bytes:
-            raise Exception(f"Video file is too large (> {max_mb} MB cap)")
+        content = _read_capped(resolved, max_mb, "Video")
         files = {"video": (resolved.name, content, mime or "application/octet-stream")}
         return await _post_streaming_generation(
             "/v1/video-to-music",
@@ -1358,9 +1402,7 @@ async def video_to_sfx(
     if video_url:
         # Same scheme guard as video_to_music: keeps file:// and flag-like
         # values away from ffprobe and the backend.
-        scheme = urlparse(video_url).scheme.lower()
-        if scheme not in ("http", "https"):
-            raise Exception("video_url must be an http:// or https:// URL")
+        _require_http_url(video_url, "video")
 
     out_path = _make_output_path(output_directory)
     cfg = _get_config()
@@ -1384,7 +1426,7 @@ async def video_to_sfx(
         if size_mb > max_mb:
             # Cheap fail-fast: avoids a wasted ffprobe run for an
             # obviously-oversized file. NOT the authoritative check — see
-            # the read-time check below.
+            # _read_capped, which enforces the cap on the bytes actually read.
             raise Exception(
                 f"Video file is too large ({size_mb:.1f} MB > {max_mb} MB cap)"
             )
@@ -1392,16 +1434,7 @@ async def video_to_sfx(
             str(resolved), max_seconds=_SFX_MAX_VIDEO_DURATION_SECONDS
         )
         mime, _ = mimetypes.guess_type(resolved.name)
-        # Authoritative check: the stat() above is now stale — an await on
-        # ffprobe sat between it and this read, during which the file could
-        # have been replaced or grown. Enforce the cap on the bytes actually
-        # read for upload, not on the earlier stat(). Reading at most
-        # max_bytes + 1 both closes that race and bounds memory use.
-        max_bytes = max_mb * 1024 * 1024
-        with open(resolved, "rb") as fh:
-            content = fh.read(max_bytes + 1)
-        if len(content) > max_bytes:
-            raise Exception(f"Video file is too large (> {max_mb} MB cap)")
+        content = _read_capped(resolved, max_mb, "Video")
         files = {
             "video": (
                 resolved.name, content, mime or "application/octet-stream"
@@ -1449,10 +1482,11 @@ async def get_sfx_task(
         body = await _http_get_json(f"/v1/tasks/{task_id}")
     except Exception as e:
         if _is_task_not_found(e):
-            # A 404 for a bad/typo'd id, or a music task's id — /v1/tasks
-            # is SFX-only and 404s those. Retrying can never help, so raise
-            # the original error as-is with no "call get_sfx_task again"
-            # advice attached.
+            # A 404 for a bad/typo'd id, or for an id /v1/tasks does not
+            # serve — it serves SFX and audio-ducking tasks, so a streaming
+            # (e.g. music) generation's id 404s here. Retrying can never
+            # help, so raise the original error as-is with no "call
+            # get_sfx_task again" advice attached.
             raise
         if _is_transient_error(e):
             # Structurally identical to _poll_task's GET — a transient
@@ -1506,33 +1540,6 @@ def _require_exactly_one(path: str | None, url: str | None, label: str) -> None:
         )
     if not path and not url:
         raise Exception(f"Provide either {label}_path or {label}_url")
-
-
-def _require_http_url(url: str, label: str) -> None:
-    """Restrict a caller-supplied URL to http(s) before it reaches ffprobe or
-    the backend — keeps file:// (local file disclosure), internal addresses
-    (SSRF from this machine), and "-"-prefixed values (ffprobe flag injection)
-    out. Same guard as video_to_music.
-    """
-    if urlparse(url).scheme.lower() not in ("http", "https"):
-        raise Exception(f"{label}_url must be an http:// or https:// URL")
-
-
-def _read_capped(path: Path, max_mb: int, label: str) -> bytes:
-    """Read a file for upload, enforcing the account's size cap on the bytes
-    actually read.
-
-    An earlier stat() is stale by the time we get here (an await on ffprobe
-    sat in between, during which the file could have been replaced or grown —
-    a still-writing export, a sync tool). Reading at most max_bytes + 1 both
-    closes that race and bounds memory use.
-    """
-    max_bytes = max_mb * 1024 * 1024
-    with open(path, "rb") as fh:
-        content = fh.read(max_bytes + 1)
-    if len(content) > max_bytes:
-        raise Exception(f"{label} file is too large (> {max_mb} MB cap)")
-    return content
 
 
 @mcp.tool(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3086,3 +3086,187 @@ async def test_get_sfx_task_recovers_ducking_task(monkeypatch, output_dir):
     saved = output_dir / "sfx-d-99.wav"
     assert saved.read_bytes() == b"ducked-bytes"
     assert str(saved) in result[0].text
+
+
+# ---------- audio_ducking ----------
+
+async def test_audio_ducking_requires_exactly_one_voice_input(output_dir):
+    from sonilo_mcp.api import audio_ducking
+    with pytest.raises(Exception, match="voice_path or voice_url"):
+        await audio_ducking(music_url="https://cdn.test/m.mp3")
+    with pytest.raises(Exception, match="voice_path or voice_url"):
+        await audio_ducking(
+            voice_path="/tmp/v.wav",
+            voice_url="https://cdn.test/v.wav",
+            music_url="https://cdn.test/m.mp3",
+        )
+
+
+async def test_audio_ducking_requires_exactly_one_music_input(output_dir):
+    from sonilo_mcp.api import audio_ducking
+    with pytest.raises(Exception, match="music_path or music_url"):
+        await audio_ducking(voice_url="https://cdn.test/v.wav")
+    with pytest.raises(Exception, match="music_path or music_url"):
+        await audio_ducking(
+            voice_url="https://cdn.test/v.wav",
+            music_path="/tmp/m.mp3",
+            music_url="https://cdn.test/m.mp3",
+        )
+
+
+async def test_audio_ducking_validates_missing_music_before_voice_io(
+    monkeypatch, output_dir
+):
+    # Both pairs are checked BEFORE any I/O, so a missing music input is
+    # reported even when the voice input would itself fail to resolve.
+    from sonilo_mcp.api import audio_ducking
+    with pytest.raises(Exception, match="music_path or music_url"):
+        await audio_ducking(voice_path="/nonexistent/voice.wav")
+
+
+async def test_audio_ducking_rejects_non_http_url(output_dir):
+    from sonilo_mcp.api import audio_ducking
+    with pytest.raises(Exception, match="http:// or https://"):
+        await audio_ducking(
+            voice_url="file:///etc/passwd", music_url="https://cdn.test/m.mp3"
+        )
+    with pytest.raises(Exception, match="http:// or https://"):
+        await audio_ducking(
+            voice_url="https://cdn.test/v.wav", music_url="file:///etc/passwd"
+        )
+
+
+@respx.mock
+async def test_audio_ducking_urls_only(monkeypatch, output_dir):
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    _patch_ffprobe(monkeypatch, duration=30.0)
+    submit = respx.post("https://api.test.local/v1/audio-ducking").mock(
+        return_value=httpx.Response(
+            202, json={"task_id": "d-10", "status": "processing"}
+        )
+    )
+    respx.get("https://api.test.local/v1/tasks/d-10").mock(
+        return_value=httpx.Response(200, json={
+            "task_id": "d-10", "type": "audio_ducking", "status": "succeeded",
+            "output_url": "https://r2.test/out.wav", "output_type": "audio",
+        })
+    )
+    respx.get("https://r2.test/out.wav").mock(
+        return_value=httpx.Response(200, content=b"ducked")
+    )
+    from sonilo_mcp.api import audio_ducking
+    result = await audio_ducking(
+        voice_url="https://cdn.test/podcast.wav",
+        music_url="https://cdn.test/bed.mp3",
+    )
+    sent = submit.calls.last.request
+    assert b"voice_url" in sent.content
+    assert b"music_url" in sent.content
+    saved = output_dir / "podcast-ducked.wav"
+    assert saved.read_bytes() == b"ducked"
+    assert str(saved) in result[0].text
+
+
+@respx.mock
+async def test_audio_ducking_video_voice_file_and_music_url(
+    monkeypatch, output_dir, tmp_path
+):
+    # Mixed submission: a local video voice file uploads as voice_file while
+    # music stays a URL. The result is the re-muxed mp4.
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    voice = tmp_path / "interview.mp4"
+    voice.write_bytes(b"FAKE-MP4")
+    respx.get("https://api.test.local/v1/account/services").mock(
+        return_value=httpx.Response(200, json={"max_upload_size_mb": 300})
+    )
+    _patch_ffprobe(monkeypatch, duration=45.0)
+    submit = respx.post("https://api.test.local/v1/audio-ducking").mock(
+        return_value=httpx.Response(
+            202, json={"task_id": "d-11", "status": "processing"}
+        )
+    )
+    respx.get("https://api.test.local/v1/tasks/d-11").mock(
+        return_value=httpx.Response(200, json={
+            "task_id": "d-11", "type": "audio_ducking", "status": "succeeded",
+            "output_url": "https://r2.test/out.mp4", "output_type": "video",
+        })
+    )
+    respx.get("https://r2.test/out.mp4").mock(
+        return_value=httpx.Response(200, content=b"muxed")
+    )
+    from sonilo_mcp.api import _reset_services_cache, audio_ducking
+    _reset_services_cache()
+    result = await audio_ducking(
+        voice_path=str(voice), music_url="https://cdn.test/bed.mp3"
+    )
+    body = submit.calls.last.request.content
+    assert b"voice_file" in body
+    assert b"FAKE-MP4" in body
+    assert b"music_url" in body
+    saved = output_dir / "interview-ducked.mp4"
+    assert saved.read_bytes() == b"muxed"
+    assert str(saved) in result[0].text
+
+
+@respx.mock
+async def test_audio_ducking_rejects_too_long_voice_before_upload(
+    monkeypatch, output_dir, tmp_path
+):
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    voice = tmp_path / "long.wav"
+    voice.write_bytes(b"FAKE-WAV")
+    respx.get("https://api.test.local/v1/account/services").mock(
+        return_value=httpx.Response(200, json={"max_upload_size_mb": 300})
+    )
+    submit = respx.post("https://api.test.local/v1/audio-ducking").mock(
+        return_value=httpx.Response(202, json={"task_id": "nope"})
+    )
+    _patch_ffprobe(monkeypatch, duration=400.0)
+    from sonilo_mcp.api import _reset_services_cache, audio_ducking
+    _reset_services_cache()
+    with pytest.raises(Exception, match="exceeds the maximum"):
+        await audio_ducking(
+            voice_path=str(voice), music_url="https://cdn.test/bed.mp3"
+        )
+    assert submit.call_count == 0
+
+
+@respx.mock
+async def test_audio_ducking_rejects_oversized_voice_file(
+    monkeypatch, output_dir, tmp_path
+):
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    voice = tmp_path / "big.wav"
+    voice.write_bytes(b"x" * (2 * 1024 * 1024))
+    respx.get("https://api.test.local/v1/account/services").mock(
+        return_value=httpx.Response(200, json={"max_upload_size_mb": 1})
+    )
+    submit = respx.post("https://api.test.local/v1/audio-ducking").mock(
+        return_value=httpx.Response(202, json={"task_id": "nope"})
+    )
+    _patch_ffprobe(monkeypatch, duration=10.0)
+    from sonilo_mcp.api import _reset_services_cache, audio_ducking
+    _reset_services_cache()
+    with pytest.raises(Exception, match="too large"):
+        await audio_ducking(
+            voice_path=str(voice), music_url="https://cdn.test/bed.mp3"
+        )
+    assert submit.call_count == 0
+
+
+async def test_audio_ducking_rejects_video_music_file(
+    monkeypatch, output_dir, tmp_path
+):
+    # The backend never probes the music input for a video stream, so a
+    # video there is a mistake — reject it locally with a clear message.
+    music = tmp_path / "bed.mp4"
+    music.write_bytes(b"FAKE-MP4")
+    from sonilo_mcp.api import audio_ducking
+    with pytest.raises(Exception, match="not a recognized audio format"):
+        await audio_ducking(
+            voice_url="https://cdn.test/v.wav", music_path=str(music)
+        )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -59,6 +59,37 @@ def test_slugify_caps_length():
     assert _slugify("Happy Song Title") == "happy-song-title"
 
 
+def test_ducking_base_name_from_path():
+    from sonilo_mcp.api import _ducking_base_name
+    assert _ducking_base_name("/tmp/Interview Take 2.mp4", None, "t-abcdefgh") == (
+        "interview-take-2-ducked"
+    )
+
+
+def test_ducking_base_name_from_url_strips_query():
+    from sonilo_mcp.api import _ducking_base_name
+    name = _ducking_base_name(
+        None, "https://cdn.test/clips/voice.wav?sig=abc#frag", "t-abcdefgh"
+    )
+    assert name == "voice-ducked"
+
+
+def test_ducking_base_name_falls_back_to_task_id():
+    # A URL with no usable filename (bare host, trailing slash) leaves
+    # nothing to name the file after. "t-abcdefgh"[:8] == "t-abcdef".
+    from sonilo_mcp.api import _ducking_base_name
+    assert _ducking_base_name(None, "https://cdn.test/", "t-abcdefgh") == (
+        "ducked-t-abcdef"
+    )
+
+
+def test_ducking_base_name_truncates_long_stem():
+    from sonilo_mcp.api import _ducking_base_name
+    name = _ducking_base_name("/tmp/" + "a" * 200 + ".wav", None, "t-abcdefgh")
+    # _slugify caps the stem at 80 chars; the suffix is added after.
+    assert name == "a" * 80 + "-ducked"
+
+
 def test_is_file_writeable_existing(tmp_path):
     from sonilo_mcp.api import _is_file_writeable
     f = tmp_path / "x.txt"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1894,7 +1894,8 @@ async def test_normalize_task_envelope_audio_output():
         "task_id": "d-1", "status": "succeeded", "type": "audio_ducking",
         "output_url": "https://r2.test/ducked.wav", "output_type": "audio",
     }
-    out = _normalize_task_envelope(body)
+    out, is_ducking = _normalize_task_envelope(body)
+    assert is_ducking is True
     assert out["audio"] == {
         "url": "https://r2.test/ducked.wav", "content_type": "audio/wav"
     }
@@ -1913,7 +1914,9 @@ async def test_normalize_task_envelope_video_output():
         "task_id": "d-2", "status": "succeeded", "type": "audio_ducking",
         "output_url": "https://r2.test/ducked.mp4", "output_type": "video",
     }
-    out = _normalize_task_envelope(body)
+    out, is_ducking = _normalize_task_envelope(body)
+    # The flag is what earns this envelope its no-audio exemption downstream.
+    assert is_ducking is True
     assert out["video"] == {
         "url": "https://r2.test/ducked.mp4", "content_type": "video/mp4"
     }
@@ -1926,7 +1929,9 @@ def test_normalize_task_envelope_passes_sfx_body_through():
         "status": "succeeded",
         "audio": {"url": "https://r2.test/a.m4a", "content_type": "audio/mp4"},
     }
-    assert _normalize_task_envelope(body) == body
+    # is_ducking is False, which is what holds SFX bodies to the audio
+    # requirement in _save_task_artifacts.
+    assert _normalize_task_envelope(body) == (body, False)
 
 
 @respx.mock
@@ -1981,6 +1986,64 @@ async def test_save_task_artifacts_no_artifacts_still_raises(monkeypatch, tmp_pa
     assert "no audio artifact" in msg
     assert "d-5" in msg
     assert "get_sfx_task" in msg
+
+
+@respx.mock
+async def test_save_task_artifacts_sfx_video_without_audio_still_raises(
+    monkeypatch, tmp_path
+):
+    # An SFX-shaped body is NOT a ducking envelope: it must always carry an
+    # audio artifact. A video-only SFX body means the audio half of a paid
+    # result went missing — downloading just the mp4 and reporting success
+    # would silently lose it, so this still raises the charged-and-
+    # recoverable error. (The video-only exemption belongs to ducking alone.)
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    route = respx.get("https://r2.test/orphan.mp4").mock(
+        return_value=httpx.Response(200, content=b"mp4-bytes")
+    )
+    from sonilo_mcp.api import _save_task_artifacts
+    body = {
+        "task_id": "t-orphan", "status": "succeeded",
+        "video": {"url": "https://r2.test/orphan.mp4", "content_type": "video/mp4"},
+    }
+    with pytest.raises(Exception) as exc:
+        await _save_task_artifacts(body, tmp_path, "scene", "t-orphan")
+    msg = str(exc.value)
+    assert "no audio artifact was returned" in msg
+    assert "t-orphan" in msg
+    assert 'get_sfx_task("t-orphan")' in msg
+    # Nothing was downloaded or written: the guard fires before any artifact
+    # work, so the user isn't handed a half-result presented as success.
+    assert route.call_count == 0
+    assert list(tmp_path.iterdir()) == []
+
+
+@respx.mock
+async def test_save_task_artifacts_ducking_video_only_download_failure(
+    monkeypatch, tmp_path
+):
+    # A video-only ducking result whose single artifact fails to download.
+    # There is no audio_dest, so the message must NOT claim an audio file was
+    # saved — it must be the plain charged-and-recoverable wording, carrying
+    # the task_id and the get_sfx_task retry call.
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    respx.get("https://r2.test/ducked-fail.mp4").mock(
+        return_value=httpx.Response(500, text="boom")
+    )
+    from sonilo_mcp.api import _save_task_artifacts
+    body = {
+        "task_id": "d-7", "status": "succeeded",
+        "output_url": "https://r2.test/ducked-fail.mp4", "output_type": "video",
+    }
+    with pytest.raises(Exception) as exc:
+        await _save_task_artifacts(body, tmp_path, "interview-ducked", "d-7")
+    msg = str(exc.value)
+    assert "d-7" in msg
+    assert 'get_sfx_task("d-7")' in msg
+    assert "The audio file was already saved" not in msg
+    # The reserved-but-unpopulated file is cleaned up, so a retry lands on the
+    # canonical path rather than an orphaning -1 suffix.
+    assert list(tmp_path.iterdir()) == []
 
 
 @respx.mock

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1885,6 +1885,127 @@ async def test_save_task_artifacts_concurrent_calls_get_distinct_files(
 
 
 @respx.mock
+async def test_normalize_task_envelope_audio_output():
+    # Ducking's flat envelope for an audio voice input becomes the SFX
+    # audio shape, with a .wav-implying content_type (ducking always
+    # renders wav; the envelope carries no content_type of its own).
+    from sonilo_mcp.api import _normalize_task_envelope
+    body = {
+        "task_id": "d-1", "status": "succeeded", "type": "audio_ducking",
+        "output_url": "https://r2.test/ducked.wav", "output_type": "audio",
+    }
+    out = _normalize_task_envelope(body)
+    assert out["audio"] == {
+        "url": "https://r2.test/ducked.wav", "content_type": "audio/wav"
+    }
+    assert "video" not in out
+    # The input body must not be mutated in place.
+    assert "audio" not in body
+
+
+@respx.mock
+async def test_normalize_task_envelope_video_output():
+    # A video voice input yields ONE artifact: the re-muxed mp4. It maps to
+    # the video slot, and there is deliberately no audio slot — the ducked
+    # audio is inside the mp4.
+    from sonilo_mcp.api import _normalize_task_envelope
+    body = {
+        "task_id": "d-2", "status": "succeeded", "type": "audio_ducking",
+        "output_url": "https://r2.test/ducked.mp4", "output_type": "video",
+    }
+    out = _normalize_task_envelope(body)
+    assert out["video"] == {
+        "url": "https://r2.test/ducked.mp4", "content_type": "video/mp4"
+    }
+    assert "audio" not in out
+
+
+def test_normalize_task_envelope_passes_sfx_body_through():
+    from sonilo_mcp.api import _normalize_task_envelope
+    body = {
+        "status": "succeeded",
+        "audio": {"url": "https://r2.test/a.m4a", "content_type": "audio/mp4"},
+    }
+    assert _normalize_task_envelope(body) == body
+
+
+@respx.mock
+async def test_save_task_artifacts_ducking_audio_envelope(monkeypatch, tmp_path):
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    respx.get("https://r2.test/ducked.wav").mock(
+        return_value=httpx.Response(200, content=b"ducked-wav-bytes")
+    )
+    from sonilo_mcp.api import _save_task_artifacts
+    body = {
+        "task_id": "d-3", "status": "succeeded",
+        "output_url": "https://r2.test/ducked.wav", "output_type": "audio",
+    }
+    result = await _save_task_artifacts(body, tmp_path, "interview-ducked", "d-3")
+    assert len(result) == 1
+    expected = tmp_path / "interview-ducked.wav"
+    assert expected.read_bytes() == b"ducked-wav-bytes"
+    assert str(expected) in result[0].text
+
+
+@respx.mock
+async def test_save_task_artifacts_ducking_video_envelope(monkeypatch, tmp_path):
+    # The video-only case: no audio artifact exists, and that is CORRECT —
+    # it must not raise "no audio artifact was returned".
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    respx.get("https://r2.test/ducked.mp4").mock(
+        return_value=httpx.Response(200, content=b"ducked-mp4-bytes")
+    )
+    from sonilo_mcp.api import _save_task_artifacts
+    body = {
+        "task_id": "d-4", "status": "succeeded",
+        "output_url": "https://r2.test/ducked.mp4", "output_type": "video",
+    }
+    result = await _save_task_artifacts(body, tmp_path, "interview-ducked", "d-4")
+    assert len(result) == 1
+    expected = tmp_path / "interview-ducked.mp4"
+    assert expected.read_bytes() == b"ducked-mp4-bytes"
+    assert str(expected) in result[0].text
+
+
+@respx.mock
+async def test_save_task_artifacts_no_artifacts_still_raises(monkeypatch, tmp_path):
+    # A succeeded body with NEITHER artifact is still a contract violation,
+    # and the message must keep the task_id + recovery call: the task was
+    # already charged.
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    from sonilo_mcp.api import _save_task_artifacts
+    body = {"task_id": "d-5", "status": "succeeded"}
+    with pytest.raises(Exception) as exc:
+        await _save_task_artifacts(body, tmp_path, "x", "d-5")
+    msg = str(exc.value)
+    assert "no audio artifact" in msg
+    assert "d-5" in msg
+    assert "get_sfx_task" in msg
+
+
+@respx.mock
+async def test_save_task_artifacts_ducking_reuse_existing(monkeypatch, tmp_path):
+    # Ducking envelopes carry no file_size, so reuse falls back to the
+    # documented "non-empty means already downloaded" branch.
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    route = respx.get("https://r2.test/ducked.wav").mock(
+        return_value=httpx.Response(200, content=b"fresh")
+    )
+    (tmp_path / "interview-ducked.wav").write_bytes(b"already-here")
+    from sonilo_mcp.api import _save_task_artifacts
+    body = {
+        "task_id": "d-6", "status": "succeeded",
+        "output_url": "https://r2.test/ducked.wav", "output_type": "audio",
+    }
+    result = await _save_task_artifacts(
+        body, tmp_path, "interview-ducked", "d-6", reuse_existing=True
+    )
+    assert route.call_count == 0
+    assert (tmp_path / "interview-ducked.wav").read_bytes() == b"already-here"
+    assert "Already downloaded" in result[0].text
+
+
+@respx.mock
 async def test_save_task_artifacts_audio_only(monkeypatch, tmp_path):
     monkeypatch.setenv("SONILO_API_KEY", "k")
     respx.get("https://r2.test/a.m4a").mock(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1129,46 +1129,55 @@ def _patch_ffprobe(monkeypatch, *, duration=None, returncode=0, installed=True):
     monkeypatch.setattr(api.asyncio, "create_subprocess_exec", fake_exec)
 
 
-async def test_check_video_duration_rejects_too_long(monkeypatch):
-    from sonilo_mcp.api import _check_video_duration
+async def test_check_media_duration_rejects_too_long(monkeypatch):
+    from sonilo_mcp.api import _check_media_duration
     _patch_ffprobe(monkeypatch, duration=400.0)
     with pytest.raises(Exception, match="exceeds the maximum"):
-        await _check_video_duration("/tmp/clip.mp4")
+        await _check_media_duration("/tmp/clip.mp4")
 
 
-async def test_check_video_duration_allows_within_limit(monkeypatch):
-    from sonilo_mcp.api import _check_video_duration
+async def test_check_media_duration_allows_within_limit(monkeypatch):
+    from sonilo_mcp.api import _check_media_duration
     _patch_ffprobe(monkeypatch, duration=120.0)
-    await _check_video_duration("/tmp/clip.mp4")  # must not raise
+    await _check_media_duration("/tmp/clip.mp4")  # must not raise
 
 
-async def test_check_video_duration_skips_without_ffprobe(monkeypatch):
-    from sonilo_mcp.api import _check_video_duration
+async def test_check_media_duration_skips_without_ffprobe(monkeypatch):
+    from sonilo_mcp.api import _check_media_duration
     _patch_ffprobe(monkeypatch, duration=400.0, installed=False)
     # ffprobe missing -> fail open, no raise even though it would be too long.
-    await _check_video_duration("/tmp/clip.mp4")
+    await _check_media_duration("/tmp/clip.mp4")
 
 
-async def test_check_video_duration_fails_open_on_probe_error(monkeypatch):
-    from sonilo_mcp.api import _check_video_duration
+async def test_check_media_duration_fails_open_on_probe_error(monkeypatch):
+    from sonilo_mcp.api import _check_media_duration
     _patch_ffprobe(monkeypatch, returncode=1)  # ffprobe couldn't read it
-    await _check_video_duration("/tmp/clip.mp4")  # must not raise
+    await _check_media_duration("/tmp/clip.mp4")  # must not raise
 
 
-async def test_check_video_duration_sfx_cap_rejects_200s(monkeypatch):
-    from sonilo_mcp.api import _check_video_duration, _SFX_MAX_VIDEO_DURATION_SECONDS
+async def test_check_media_duration_sfx_cap_rejects_200s(monkeypatch):
+    from sonilo_mcp.api import _check_media_duration, _SFX_MAX_VIDEO_DURATION_SECONDS
     _patch_ffprobe(monkeypatch, duration=200.0)
     with pytest.raises(Exception, match="exceeds the maximum"):
-        await _check_video_duration(
+        await _check_media_duration(
             "/tmp/clip.mp4", max_seconds=_SFX_MAX_VIDEO_DURATION_SECONDS
         )
 
 
-async def test_check_video_duration_music_cap_allows_200s(monkeypatch):
-    from sonilo_mcp.api import _check_video_duration
+async def test_check_media_duration_music_cap_allows_200s(monkeypatch):
+    from sonilo_mcp.api import _check_media_duration
     _patch_ffprobe(monkeypatch, duration=200.0)
     # Default cap stays 360s — 200s must not raise.
-    await _check_video_duration("/tmp/clip.mp4")
+    await _check_media_duration("/tmp/clip.mp4")
+
+
+async def test_check_media_duration_probes_plain_audio(monkeypatch):
+    # ffprobe reports format.duration for audio files too — the ducking
+    # tool relies on this to pre-check voice/music audio inputs.
+    from sonilo_mcp.api import _check_media_duration
+    _patch_ffprobe(monkeypatch, duration=400.0)
+    with pytest.raises(Exception, match="exceeds the maximum"):
+        await _check_media_duration("/tmp/voice.wav")
 
 
 @respx.mock

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1186,6 +1186,19 @@ async def test_check_media_duration_fails_open_on_probe_error(monkeypatch):
     await _check_media_duration("/tmp/clip.mp4")  # must not raise
 
 
+async def test_check_media_duration_fails_open_on_nul_byte_source(monkeypatch):
+    # A source containing an embedded NUL byte makes the REAL
+    # create_subprocess_exec raise ValueError("embedded null byte") before it
+    # spawns. This best-effort helper must fail open (stay silent) rather than
+    # let that ValueError crash the whole request.
+    from sonilo_mcp import api
+    from sonilo_mcp.api import _check_media_duration
+    # ffprobe "installed" so we don't short-circuit; use the real subprocess
+    # launcher (not the fake) so the NUL byte actually triggers the ValueError.
+    monkeypatch.setattr(api.shutil, "which", lambda name: "/usr/bin/ffprobe")
+    await _check_media_duration("https://e.com/a\x00.mp4")  # must not raise
+
+
 async def test_check_media_duration_sfx_cap_rejects_200s(monkeypatch):
     from sonilo_mcp.api import _check_media_duration, _SFX_MAX_VIDEO_DURATION_SECONDS
     _patch_ffprobe(monkeypatch, duration=200.0)
@@ -2007,9 +2020,12 @@ async def test_save_task_artifacts_unknown_output_type_raises_recoverable(
     with pytest.raises(Exception) as exc:
         await _save_task_artifacts(body, tmp_path, "interview-ducked", "d-7")
     msg = str(exc.value)
-    assert "no audio artifact" in msg
+    # get_sfx_task would re-run the same normalization and loop forever on this
+    # body, so the message must instead surface the output_url + output_type so
+    # the paid result can be fetched manually — while still carrying the task_id.
+    assert "https://r2.test/ducked.bin" in msg
+    assert "waveform" in msg
     assert "d-7" in msg
-    assert "get_sfx_task" in msg
     assert download.call_count == 0
     assert list(tmp_path.iterdir()) == []
 
@@ -3483,4 +3499,139 @@ async def test_audio_ducking_size_cap_enforced_on_actual_bytes(
             voice_path=str(voice), music_url="https://cdn.test/bed.mp3"
         )
     # Must NOT charge — the oversized bytes must never be uploaded.
+    assert submit.call_count == 0
+
+
+@respx.mock
+async def test_audio_ducking_rejects_too_long_voice_url_before_post(
+    monkeypatch, output_dir, tmp_path
+):
+    # URL-input mirror of the file-input over-long guard: an over-long
+    # voice_url must be caught by the ffprobe pre-check BEFORE the POST that
+    # charges. Without this, a future refactor could drop the URL-branch check
+    # and silently bill the user for an over-long URL input.
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    submit = respx.post("https://api.test.local/v1/audio-ducking").mock(
+        return_value=httpx.Response(202, json={"task_id": "nope"})
+    )
+    # Only the voice URL is over-long (music well within the cap), so the
+    # rejection is unambiguously the voice-URL check.
+    _patch_ffprobe_per_source(monkeypatch, {"podcast": 420.0}, default=30.0)
+    from sonilo_mcp.api import _reset_services_cache, audio_ducking
+    _reset_services_cache()
+    with pytest.raises(Exception, match="exceeds the maximum"):
+        await audio_ducking(
+            voice_url="https://cdn.test/podcast.wav",
+            music_url="https://cdn.test/bed.mp3",
+        )
+    assert submit.call_count == 0
+
+
+@respx.mock
+async def test_audio_ducking_rejects_too_long_music_url_before_post(
+    monkeypatch, output_dir, tmp_path
+):
+    # Same as above for the music_url input: its own 360s cap must be enforced
+    # before the charge even when the voice URL is well within the limit.
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    submit = respx.post("https://api.test.local/v1/audio-ducking").mock(
+        return_value=httpx.Response(202, json={"task_id": "nope"})
+    )
+    # Only the music URL is over-long — pins the music-URL check independently.
+    _patch_ffprobe_per_source(monkeypatch, {"bed": 420.0}, default=30.0)
+    from sonilo_mcp.api import _reset_services_cache, audio_ducking
+    _reset_services_cache()
+    with pytest.raises(Exception, match="exceeds the maximum"):
+        await audio_ducking(
+            voice_url="https://cdn.test/podcast.wav",
+            music_url="https://cdn.test/bed.mp3",
+        )
+    assert submit.call_count == 0
+
+
+@respx.mock
+async def test_audio_ducking_stat_fail_fast_rejects_oversized_voice(
+    monkeypatch, output_dir, tmp_path
+):
+    # Pins the stat() fail-fast guard INDEPENDENTLY of _read_capped: stat sees
+    # an oversized file, but by the time the bytes are read the file is small,
+    # so only the fail-fast stat check can catch it. If that guard were deleted,
+    # _read_capped would read the (now small) bytes and let the charge through.
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    from sonilo_mcp import api
+
+    voice = tmp_path / "voice.wav"
+    voice.write_bytes(b"x" * (2 * 1024 * 1024))
+
+    respx.get("https://api.test.local/v1/account/services").mock(
+        return_value=httpx.Response(200, json={"max_upload_size_mb": 1})
+    )
+    api._reset_services_cache()
+
+    real_check = api._check_media_duration
+
+    async def shrinking_check(source, **kwargs):
+        # The file shrinks to a handful of bytes while the caller awaits the
+        # pre-check — after stat() has already seen it oversized.
+        if "voice.wav" in source:
+            voice.write_bytes(b"y" * 16)
+        return await real_check(source, **kwargs)
+
+    _patch_ffprobe(monkeypatch, duration=30.0)
+    monkeypatch.setattr(api, "_check_media_duration", shrinking_check)
+
+    submit = respx.post("https://api.test.local/v1/audio-ducking").mock(
+        return_value=httpx.Response(202, json={"task_id": "nope"})
+    )
+
+    with pytest.raises(Exception, match="Voice file is too large"):
+        await api.audio_ducking(
+            voice_path=str(voice), music_url="https://cdn.test/bed.mp3"
+        )
+    assert submit.call_count == 0
+
+
+@respx.mock
+async def test_audio_ducking_stat_fail_fast_rejects_oversized_music(
+    monkeypatch, output_dir, tmp_path
+):
+    # Music-side mirror of the stat() fail-fast guard: stat sees the music file
+    # oversized, but it shrinks before its bytes are read — only the fail-fast
+    # stat check can catch it.
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    from sonilo_mcp import api
+
+    music = tmp_path / "bed.mp3"
+    music.write_bytes(b"x" * (2 * 1024 * 1024))
+
+    respx.get("https://api.test.local/v1/account/services").mock(
+        return_value=httpx.Response(200, json={"max_upload_size_mb": 1})
+    )
+    api._reset_services_cache()
+
+    real_check = api._check_media_duration
+
+    async def shrinking_check(source, **kwargs):
+        # Shrink ONLY the music file, and only when its own pre-check runs (the
+        # voice pre-check runs first with a different source). This keeps the
+        # music file oversized at the moment its stat() guard runs.
+        if "bed.mp3" in source:
+            music.write_bytes(b"y" * 16)
+        return await real_check(source, **kwargs)
+
+    _patch_ffprobe(monkeypatch, duration=30.0)
+    monkeypatch.setattr(api, "_check_media_duration", shrinking_check)
+
+    submit = respx.post("https://api.test.local/v1/audio-ducking").mock(
+        return_value=httpx.Response(202, json={"task_id": "nope"})
+    )
+
+    with pytest.raises(Exception, match="Music file is too large"):
+        await api.audio_ducking(
+            voice_url="https://cdn.test/podcast.wav", music_path=str(music)
+        )
     assert submit.call_count == 0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3030,3 +3030,28 @@ async def test_get_sfx_task_video_task_reuse_returns_both_paths(monkeypatch, out
     assert audio_route.call_count == 1
     assert video_route.call_count == 1
     assert sum("already downloaded" in c.text.lower() for c in second) == 2
+
+
+@respx.mock
+async def test_get_sfx_task_recovers_ducking_task(monkeypatch, output_dir):
+    # Regression: /v1/tasks serves SFX *and* audio-ducking tasks (the
+    # backend's POLLABLE_TASK_TYPES covers both), but get_sfx_task used to
+    # fetch a valid ducking body and then fail with "no audio artifact was
+    # returned". It must download the result instead.
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    respx.get("https://api.test.local/v1/tasks/d-99").mock(
+        return_value=httpx.Response(200, json={
+            "task_id": "d-99", "type": "audio_ducking", "status": "succeeded",
+            "output_url": "https://r2.test/ducked.wav",
+            "output_type": "audio",
+        })
+    )
+    respx.get("https://r2.test/ducked.wav").mock(
+        return_value=httpx.Response(200, content=b"ducked-bytes")
+    )
+    from sonilo_mcp.api import get_sfx_task
+    result = await get_sfx_task("d-99")
+    saved = output_dir / "sfx-d-99.wav"
+    assert saved.read_bytes() == b"ducked-bytes"
+    assert str(saved) in result[0].text

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1915,8 +1915,7 @@ async def test_save_task_artifacts_concurrent_calls_get_distinct_files(
     assert payloads == {b"AUDIO-DATA-1", b"AUDIO-DATA-2"}
 
 
-@respx.mock
-async def test_normalize_task_envelope_audio_output():
+def test_normalize_task_envelope_audio_output():
     # Ducking's flat envelope for an audio voice input becomes the SFX
     # audio shape, with a .wav-implying content_type (ducking always
     # renders wav; the envelope carries no content_type of its own).
@@ -1935,8 +1934,7 @@ async def test_normalize_task_envelope_audio_output():
     assert "audio" not in body
 
 
-@respx.mock
-async def test_normalize_task_envelope_video_output():
+def test_normalize_task_envelope_video_output():
     # A video voice input yields ONE artifact: the re-muxed mp4. It maps to
     # the video slot, and there is deliberately no audio slot — the ducked
     # audio is inside the mp4.
@@ -1963,6 +1961,57 @@ def test_normalize_task_envelope_passes_sfx_body_through():
     # is_ducking is False, which is what holds SFX bodies to the audio
     # requirement in _save_task_artifacts.
     assert _normalize_task_envelope(body) == (body, False)
+
+
+@pytest.mark.parametrize(
+    "output_type",
+    [None, "", "audio/wav", "AUDIO", "image", 7, ["audio"]],
+)
+def test_normalize_task_envelope_rejects_unknown_output_type(output_type):
+    # An unrecognized (or missing, or non-string) output_type alongside a
+    # valid output_url must NOT be normalized. Defaulting it to "audio" would
+    # download the artifact, write it with a fabricated .wav extension and
+    # report success — silently mislabeling a paid result. It must fall
+    # through as a non-ducking body instead, so _save_task_artifacts raises
+    # its charged-and-recoverable error carrying the task_id.
+    from sonilo_mcp.api import _normalize_task_envelope
+    body = {
+        "task_id": "d-6", "status": "succeeded",
+        "output_url": "https://r2.test/ducked.bin",
+    }
+    if output_type is not None:
+        body["output_type"] = output_type
+    out, is_ducking = _normalize_task_envelope(body)
+    assert is_ducking is False
+    assert out == body
+    assert "audio" not in out
+    assert "video" not in out
+
+
+@respx.mock
+async def test_save_task_artifacts_unknown_output_type_raises_recoverable(
+    monkeypatch, tmp_path
+):
+    # End-to-end consequence of the above: nothing is downloaded, nothing is
+    # written, and the error keeps the task_id + get_sfx_task hint — the
+    # result is still on the backend.
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    download = respx.get("https://r2.test/ducked.bin").mock(
+        return_value=httpx.Response(200, content=b"mystery")
+    )
+    from sonilo_mcp.api import _save_task_artifacts
+    body = {
+        "task_id": "d-7", "status": "succeeded",
+        "output_url": "https://r2.test/ducked.bin", "output_type": "waveform",
+    }
+    with pytest.raises(Exception) as exc:
+        await _save_task_artifacts(body, tmp_path, "interview-ducked", "d-7")
+    msg = str(exc.value)
+    assert "no audio artifact" in msg
+    assert "d-7" in msg
+    assert "get_sfx_task" in msg
+    assert download.call_count == 0
+    assert list(tmp_path.iterdir()) == []
 
 
 @respx.mock
@@ -3270,3 +3319,168 @@ async def test_audio_ducking_rejects_video_music_file(
         await audio_ducking(
             voice_url="https://cdn.test/v.wav", music_path=str(music)
         )
+
+
+def _patch_ffprobe_per_source(monkeypatch, durations: dict, default=30.0):
+    """Fake ffprobe whose reported duration depends on the source argument.
+
+    `durations` maps a substring of the source (a path or URL) to the
+    duration to report for it; anything unmatched gets `default`. Needed to
+    exercise the MUSIC-side duration cap without the VOICE input tripping
+    first.
+    """
+    from sonilo_mcp import api
+
+    monkeypatch.setattr(api.shutil, "which", lambda name: "/usr/bin/ffprobe")
+
+    async def fake_exec(*args, **kwargs):
+        source = args[-1]
+        duration = default
+        for needle, value in durations.items():
+            if needle in source:
+                duration = value
+        payload = json.dumps({"format": {"duration": str(duration)}}).encode()
+        return _FakeProc(payload, returncode=0)
+
+    monkeypatch.setattr(api.asyncio, "create_subprocess_exec", fake_exec)
+
+
+@respx.mock
+async def test_audio_ducking_music_file_and_voice_url(
+    monkeypatch, output_dir, tmp_path
+):
+    # Mixed submission the other way round: the music bed is a local file
+    # (uploaded as the music_file part) while the voice stays a URL.
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    music = tmp_path / "bed.mp3"
+    music.write_bytes(b"FAKE-MP3")
+    respx.get("https://api.test.local/v1/account/services").mock(
+        return_value=httpx.Response(200, json={"max_upload_size_mb": 300})
+    )
+    _patch_ffprobe(monkeypatch, duration=30.0)
+    submit = respx.post("https://api.test.local/v1/audio-ducking").mock(
+        return_value=httpx.Response(
+            202, json={"task_id": "d-12", "status": "processing"}
+        )
+    )
+    respx.get("https://api.test.local/v1/tasks/d-12").mock(
+        return_value=httpx.Response(200, json={
+            "task_id": "d-12", "type": "audio_ducking", "status": "succeeded",
+            "output_url": "https://r2.test/out.wav", "output_type": "audio",
+        })
+    )
+    respx.get("https://r2.test/out.wav").mock(
+        return_value=httpx.Response(200, content=b"ducked")
+    )
+    from sonilo_mcp.api import _reset_services_cache, audio_ducking
+    _reset_services_cache()
+    result = await audio_ducking(
+        voice_url="https://cdn.test/podcast.wav", music_path=str(music)
+    )
+    body = submit.calls.last.request.content
+    # The music file rides as the `music_file` multipart part, alongside the
+    # voice_url form field.
+    assert b'name="music_file"' in body
+    assert b"FAKE-MP3" in body
+    assert b'name="voice_url"' in body
+    assert b"https://cdn.test/podcast.wav" in body
+    saved = output_dir / "podcast-ducked.wav"
+    assert saved.read_bytes() == b"ducked"
+    assert str(saved) in result[0].text
+
+
+@respx.mock
+async def test_audio_ducking_rejects_oversized_music_file(
+    monkeypatch, output_dir, tmp_path
+):
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    music = tmp_path / "big.mp3"
+    music.write_bytes(b"x" * (2 * 1024 * 1024))
+    respx.get("https://api.test.local/v1/account/services").mock(
+        return_value=httpx.Response(200, json={"max_upload_size_mb": 1})
+    )
+    submit = respx.post("https://api.test.local/v1/audio-ducking").mock(
+        return_value=httpx.Response(202, json={"task_id": "nope"})
+    )
+    _patch_ffprobe(monkeypatch, duration=10.0)
+    from sonilo_mcp.api import _reset_services_cache, audio_ducking
+    _reset_services_cache()
+    with pytest.raises(Exception, match="Music file is too large"):
+        await audio_ducking(
+            voice_url="https://cdn.test/podcast.wav", music_path=str(music)
+        )
+    # Rejected before the charge.
+    assert submit.call_count == 0
+
+
+@respx.mock
+async def test_audio_ducking_rejects_too_long_music_before_upload(
+    monkeypatch, output_dir, tmp_path
+):
+    # The music input has its own 360s cap: an over-long bed must be caught
+    # even when the voice input is well within the limit.
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    music = tmp_path / "long-bed.mp3"
+    music.write_bytes(b"FAKE-MP3")
+    respx.get("https://api.test.local/v1/account/services").mock(
+        return_value=httpx.Response(200, json={"max_upload_size_mb": 300})
+    )
+    submit = respx.post("https://api.test.local/v1/audio-ducking").mock(
+        return_value=httpx.Response(202, json={"task_id": "nope"})
+    )
+    _patch_ffprobe_per_source(
+        monkeypatch, {"long-bed.mp3": 420.0}, default=30.0
+    )
+    from sonilo_mcp.api import _reset_services_cache, audio_ducking
+    _reset_services_cache()
+    with pytest.raises(Exception, match="exceeds the maximum"):
+        await audio_ducking(
+            voice_url="https://cdn.test/podcast.wav", music_path=str(music)
+        )
+    # Rejected before the charge.
+    assert submit.call_count == 0
+
+
+@respx.mock
+async def test_audio_ducking_size_cap_enforced_on_actual_bytes(
+    monkeypatch, output_dir, tmp_path
+):
+    # TOCTOU: the stat()-based check runs before the ffprobe await (up to
+    # 30s). If the file grows during that window, the stale check must not
+    # let the oversized bytes bypass the cap — _read_capped enforces it on
+    # what is actually read, before anything is uploaded (or charged).
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    from sonilo_mcp import api
+
+    voice = tmp_path / "voice.wav"
+    voice.write_bytes(b"\x00" * 1024)
+
+    respx.get("https://api.test.local/v1/account/services").mock(
+        return_value=httpx.Response(200, json={"max_upload_size_mb": 2})
+    )
+    api._reset_services_cache()
+
+    real_check = api._check_media_duration
+
+    async def growing_check(source, **kwargs):
+        # The file grows while the caller awaits the duration pre-check.
+        voice.write_bytes(b"\x01" * (5 * 1024 * 1024))
+        return await real_check(source, **kwargs)
+
+    _patch_ffprobe(monkeypatch, duration=30.0)
+    monkeypatch.setattr(api, "_check_media_duration", growing_check)
+
+    submit = respx.post("https://api.test.local/v1/audio-ducking").mock(
+        return_value=httpx.Response(202, json={"task_id": "nope"})
+    )
+
+    with pytest.raises(Exception, match="Voice file is too large"):
+        await api.audio_ducking(
+            voice_path=str(voice), music_url="https://cdn.test/bed.mp3"
+        )
+    # Must NOT charge — the oversized bytes must never be uploaded.
+    assert submit.call_count == 0


### PR DESCRIPTION
## Summary

Adds `audio_ducking`, an MCP tool that ducks a music bed under a voice track via the backend's `POST /v1/audio-ducking`. Ships as v0.3.0.

The endpoint shares the SFX submit-then-poll flow (same `GET /v1/tasks/{id}`), so most of the plumbing (`_post_task_submit`, `_poll_task`, artifact download) is reused. The two genuinely new pieces are the ducking success envelope (`{output_url, output_type}` vs SFX's `{audio, video}`) and the video-only result (a video voice input yields a single re-muxed `.mp4`, no separate audio).

## Tool

`audio_ducking(voice_path? | voice_url?, music_path? | music_url?, output_directory?)`

- Voice may be audio **or** video; a video voice has the ducked mix muxed back into a new `.mp4`. Music is audio only.
- Exactly-one-of per pair, validated before any I/O; a local file and a URL may be mixed across the two.
- Each input capped at 360s and the account upload-size limit. Local size cap enforced on bytes actually read; both inputs duration-pre-checked with ffprobe when installed.
- Output named `<voice>-ducked.{wav,mp4}`.

## Other changes

- `get_sfx_task` now recovers `audio_ducking` tasks too (same `/v1/tasks` endpoint). Fixes a pre-existing "no audio artifact was returned" error when a ducking task id was passed to it.
- `_check_video_duration` → `_check_media_duration` (it reads `format.duration`, which ffprobe reports for audio as well as video), reused to pre-check both ducking inputs. Now fails open on odd-character probe URLs — a NUL byte previously surfaced an uncaught `ValueError`, which also affected `video_to_music` / `video_to_sfx`.
- `video_to_music` / `video_to_sfx` now share the http(s)-scheme guard and read-time size cap with `audio_ducking` instead of inlining their own copies.

## Testing

- 211 unit tests passing (respx-stubbed). New/changed paths — envelope normalization, video-only exemption, the exactly-one-of validation, the URL/size/duration pre-checks, and every charged-and-recoverable error branch — are mutation-verified (deleting a guard fails its test).
- Verified end-to-end against production: video voice URL + local music file, 54s inputs, 35s round trip, muxed `.mp4` result with intact video + audio streams.

Not tested live: plain-audio voice, local video upload, dual-URL inputs, timeout recovery via `get_sfx_task` (all covered by unit tests only).
