### PR TITLE
fix(video_to_sfx): accept only the formats video-to-audio supports

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An MCP (Model Context Protocol) server that exposes [Sonilo](https://sonilo.com)
 
 The flagship tool is **`video_to_music`**: hand it your finished video and it composes an original soundtrack matched to the cut — the music follows the pacing, emotion, and edits because the model saw them. Length matches the video automatically. Every track is licensed and safe for commercial use (terms apply). `text_to_music` is also available for fixed-length tracks with no video to match.
 
-For sound design, **`video_to_sfx`** watches your video and generates matching sound effects, returning both the SFX audio and the finished video with the effects mixed in. `text_to_sfx` generates a standalone effect from a description.
+For sound design, **`video_to_sfx`** watches your video and generates matching sound effects, returned as a standalone audio file. `text_to_sfx` generates a standalone effect from a description.
 
 **▶ [Example result](https://github.com/cindyxu1030/sonilo-video-to-music-cookbook/blob/main/assets/demo-trailer.mp4)** — an AI-generated trailer with its soundtrack composed by `video_to_music` from the assembled cut. For recipes covering any AI-video pipeline (stitch → grade → add music → mux), see the [Sonilo video-to-music cookbook](https://github.com/cindyxu1030/sonilo-video-to-music-cookbook).
 
@@ -22,7 +22,7 @@ Get your API key from the [Sonilo dashboard](https://platform.sonilo.com/dashboa
 
 - **Video-to-music** — give it a video and Sonilo composes a full-length score matched to its pacing, motion, and emotion. Transitions and beat drops align to your cut points, and the track matches the video's duration exactly — no prompts or manual syncing required.
 - **Text-to-music** — generate tracks from a text description (genre, mood, tempo, instrumentation) at an exact duration (1–360s).
-- **Video-to-SFX** — Sonilo watches the video and generates sound effects for what it sees. You get both the SFX audio and the finished video with the effects mixed in. Optional `segments` let you script effects to specific time ranges (`[{start, end, prompt}]`).
+- **Video-to-SFX** — Sonilo watches the video and generates sound effects for what it sees. You get the SFX as a standalone audio file. Optional `segments` let you script effects to specific time ranges (`[{start, end, prompt}]`).
 - **Text-to-SFX** — generate a standalone sound effect from a description (1–180s), in `wav`, `mp3`, `aac`, or `flac`.
 - **Fully licensed, commercial-safe** — music licensed via Shutterstock; every generated track is cleared for commercial use on social, brand content, and advertising, with no Content ID worries.
 - **Pay as you go** — billed only for the seconds of music you generate; new accounts get free credits on signup.
@@ -141,7 +141,7 @@ files. To opt out — e.g. to read a video from elsewhere on disk — set
 | `text_to_music(prompt, duration, output_directory?)` | Generate music from a text prompt. | ✅ |
 | `video_to_music(video_path? \| video_url?, prompt?, output_directory?)` | Generate music matched to a video. Max duration **360s (6 min)**; subject to the account's upload-size cap (typically 300 MB). | ✅ |
 | `text_to_sfx(prompt, duration, audio_format?, output_directory?)` | Generate a sound effect from text. Duration 1–180s; formats wav/mp3/aac/flac (default aac). | ✅ |
-| `video_to_sfx(video_path? \| video_url?, prompt?, segments?, audio_format?, output_directory?)` | Generate SFX for a video; saves the SFX audio **and** the finished video with effects mixed in. Max video duration **180s (3 min)**. | ✅ |
+| `video_to_sfx(video_path? \| video_url?, prompt?, segments?, audio_format?, output_directory?)` | Generate SFX for a video; saves the generated SFX audio. Max video duration **180s (3 min)**. | ✅ |
 | `audio_ducking(voice_path? \| voice_url?, music_path? \| music_url?, output_directory?)` | Duck a music bed under a voice track. The voice input may be a video — the ducked mix is muxed back into a new `.mp4`. Each input max **360s (6 min)**; subject to the account's upload-size cap. | ✅ |
 | `get_sfx_task(task_id, output_directory?)` | Check an SFX or audio-ducking task and download its result — recovery for timed-out `text_to_sfx`, `video_to_sfx`, and `audio_ducking` calls. | ❌ |
 | `get_account_services()` | List available services and limits. | ❌ |
@@ -162,7 +162,7 @@ If a call times out, the generation keeps running (and is already charged). The 
 
 **Music** is saved as `.m4a` (AAC in MP4 container). File names use the title returned by the backend (slugified), or a `sonilo-<timestamp>.m4a` fallback. When multiple parallel streams are returned, a `-<index>` suffix is appended.
 
-**Sound effects** are saved in the requested `audio_format` — `wav`, `mp3`, `flac`, or `aac` (the default, written as `.m4a`). `video_to_sfx` additionally saves the finished video as `.mp4` alongside the audio.
+**Sound effects** are saved in the requested `audio_format` — `wav`, `mp3`, `flac`, or `aac` (the default, written as `.m4a`); `video_to_sfx` saves audio only, not the source video.
 
 File names come from the prompt (slugified, truncated to 80 characters). When there is no prompt to name a file after — `video_to_sfx` without one, or any file recovered via `get_sfx_task` — the name is `sfx-<first 8 chars of the task id>` instead. Existing files are never overwritten: a `-1`, `-2`, … suffix is added instead.
 

--- a/src/sonilo_mcp/api.py
+++ b/src/sonilo_mcp/api.py
@@ -196,6 +196,9 @@ def _ducking_base_name(
 
 _AUDIO_EXTS = frozenset({".wav", ".mp3", ".m4a", ".aac", ".ogg", ".flac"})
 _VIDEO_EXTS = frozenset({".mp4", ".mov", ".avi", ".wmv", ".webm", ".mkv"})
+# video-to-sfx (fal video-to-audio) accepts a narrower set than the locally
+# ffprobe-readable formats above — mp4, mov, webm, m4v, and animated gif.
+_SFX_VIDEO_EXTS = frozenset({".mp4", ".mov", ".webm", ".m4v", ".gif"})
 
 
 def _resolve_input_file(
@@ -1383,9 +1386,10 @@ async def text_to_sfx(
         "incur charges. Only use when explicitly requested by the user.\n\n"
         "Args:\n"
         "    video_path (str, optional): Absolute local path, or relative "
-        "to SONILO_MCP_BASE_PATH. Supports .mp4/.mov/.avi/.wmv/.webm/.mkv. "
-        "Subject to the account's max upload size (typically 300 MB). "
-        "Maximum video duration is 180 seconds (3 minutes).\n"
+        "to SONILO_MCP_BASE_PATH. Supports .mp4/.mov/.webm/.m4v/.gif "
+        "(gif must be animated). Subject to the account's max upload size "
+        "(typically 300 MB). Maximum video duration is 180 seconds "
+        "(3 minutes).\n"
         "    video_url (str, optional): HTTPS URL to a video file.\n"
         "    prompt (str, optional): Overall description of the desired "
         "sound effects (max 2000 chars).\n"
@@ -1439,7 +1443,7 @@ async def video_to_sfx(
 
     if video_path:
         resolved = _resolve_input_file(
-            video_path, cfg["base_path"], _VIDEO_EXTS, "video"
+            video_path, cfg["base_path"], _SFX_VIDEO_EXTS, "video"
         )
         max_mb = await _get_max_upload_size_mb()
         size_mb = resolved.stat().st_size / (1024 * 1024)

--- a/src/sonilo_mcp/api.py
+++ b/src/sonilo_mcp/api.py
@@ -997,8 +997,8 @@ async def _save_task_artifacts(
     failed -> raise with the backend's error code/message and whether the
     charge was refunded. succeeded -> download whichever artifacts the task
     produced — audio and/or video — one TextContent per saved file. An audio
-    artifact is required: an SFX task always has audio (plus video for
-    video-to-sfx). The sole exemption is an audio-ducking task with a video
+    artifact is required: an SFX task always has audio (video-to-sfx returns
+    audio only). The sole exemption is an audio-ducking task with a video
     voice input, whose only artifact is the re-muxed mp4 (see
     _normalize_task_envelope, which reports whether it saw that envelope).
 
@@ -1374,8 +1374,8 @@ async def text_to_sfx(
 @mcp.tool(
     description=(
         "Generate sound effects for a video: Sonilo analyzes the video and "
-        "creates matching SFX. Returns BOTH the sound-effects audio file "
-        "and the finished video with the effects mixed in. Provide either a "
+        "creates matching SFX. Returns the generated sound-effects audio "
+        "file. Provide either a "
         "local video file path or a publicly accessible video URL. "
         "Generation is asynchronous on the backend; this tool waits for "
         "completion and returns the saved file paths.\n\n"
@@ -1401,8 +1401,8 @@ async def text_to_sfx(
         "files. Defaults to SONILO_MCP_BASE_PATH.\n\n"
         "Exactly one of video_path and video_url must be provided.\n\n"
         "Returns:\n"
-        "    Two TextContents: the saved audio file path and the saved "
-        ".mp4 video path. If the call times out, the error message "
+        "    One TextContent: the saved audio file path. If the call times "
+        "out, the error message "
         "includes the task_id — recover with get_sfx_task."
     )
 )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2711,6 +2711,26 @@ async def test_video_to_sfx_both_inputs_rejected(monkeypatch, output_dir):
         await video_to_sfx()
 
 
+def test_sfx_video_exts_are_the_fal_accepted_set():
+    # video-to-sfx (fal video-to-audio) accepts exactly this set — narrower than
+    # the shared _VIDEO_EXTS used by video-to-music / audio-ducking.
+    from sonilo_mcp.api import _SFX_VIDEO_EXTS
+
+    assert _SFX_VIDEO_EXTS == {".mp4", ".mov", ".webm", ".m4v", ".gif"}
+
+
+async def test_video_to_sfx_rejects_avi_extension(monkeypatch, tmp_path):
+    # .avi is in the shared _VIDEO_EXTS but NOT accepted by video-to-audio, so
+    # video_to_sfx must reject it locally (fail fast, before any upload).
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    from sonilo_mcp.api import video_to_sfx
+
+    clip = tmp_path / "clip.avi"
+    clip.write_bytes(b"x")
+    with pytest.raises(Exception, match="not a recognized video format"):
+        await video_to_sfx(video_path=str(clip))
+
+
 @pytest.mark.parametrize("bad_url", ["file:///etc/passwd", "ftp://x/y.mp4"])
 async def test_video_to_sfx_rejects_non_http_url(monkeypatch, output_dir, bad_url):
     monkeypatch.setenv("SONILO_API_KEY", "k")


### PR DESCRIPTION
## Summary

`video_to_sfx` shared the generic `_VIDEO_EXTS` allowlist with `video_to_music` and `audio_ducking`, but the fal **video-to-audio** endpoint (which powers video-to-sfx) accepts a narrower, different set: **mp4, mov, webm, m4v, gif (animated)**.

That mismatch was wrong in both directions for SFX:
- **Blocked** `.m4v` and `.gif` locally, even though the endpoint accepts them.
- **Allowed** `.avi` / `.wmv` / `.mkv`, which the endpoint rejects — so the upload was wasted before failing.

## Change

- New `_SFX_VIDEO_EXTS = {.mp4, .mov, .webm, .m4v, .gif}`; `video_to_sfx` uses it.
- Tool description updated to the accepted set (and notes gif must be animated).
- `video_to_music` and `audio_ducking` keep the shared `_VIDEO_EXTS` — **unchanged**.

## Behavior change

`video_to_sfx` now rejects `.avi` / `.wmv` / `.mkv` locally (fail fast) and accepts `.m4v` / `.gif`. If it turns out the endpoint accepts more than the advertised set, the list is a one-line change.

## Tests

- `_SFX_VIDEO_EXTS` membership guard.
- `video_to_sfx` rejects a `.avi` path with "not a recognized video format".
- Full suite: 213 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
