### PR TITLE
feat: add isolate_vocals to video_to_music + task recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ files. To opt out — e.g. to read a video from elsewhere on disk — set
 | `text_to_sfx(prompt, duration, audio_format?, output_directory?)` | Generate a sound effect from text. Duration 1–180s; formats wav/mp3/aac/flac (default aac). | ✅ |
 | `video_to_sfx(video_path? \| video_url?, prompt?, segments?, audio_format?, output_directory?)` | Generate SFX for a video; saves the generated SFX audio. Max video duration **180s (3 min)**. | ✅ |
 | `audio_ducking(voice_path? \| voice_url?, music_path? \| music_url?, output_directory?)` | Duck a music bed under a voice track. The voice input may be a video — the ducked mix is muxed back into a new `.mp4`. Each input max **360s (6 min)**; subject to the account's upload-size cap. | ✅ |
-| `get_sfx_task(task_id, output_directory?)` | Check an SFX or audio-ducking task and download its result — recovery for timed-out `text_to_sfx`, `video_to_sfx`, and `audio_ducking` calls. | ❌ |
+| `get_sfx_task(task_id, output_directory?)` | Check an SFX, audio-ducking, or async video-to-music task and download its result — recovery for timed-out `text_to_sfx`, `video_to_sfx`, `audio_ducking`, and `video_to_music(isolate_vocals=true)` calls. | ❌ |
 | `get_account_services()` | List available services and limits. | ❌ |
 | `get_usage(days=30)` | Show usage summary + per-day breakdown. | ❌ |
 | `play_audio(input_file_path)` | Play a local audio file. | ❌ |
@@ -154,7 +154,7 @@ Tools marked ✅ make API calls that incur charges on your Sonilo account.
 
 ### Sound effects and ducking run as tasks
 
-The music tools stream their result and finish in one call — with one exception: `video_to_music(isolate_vocals=true)` submits a *task* and polls it internally instead, the same way the SFX tools do (see below), because separating vocals is only available in the backend's async mode. You still get the saved file paths back from a single call; you just don't see the task. The SFX tools submit a *task*, then poll it until it completes — `text_to_sfx` and `video_to_sfx` do this for you and return the saved file paths, so you normally never see the task. `audio_ducking` uses the same submit-then-poll flow and the same `get_sfx_task` recovery path.
+The music tools stream their result and finish in one call — with one exception: `video_to_music(isolate_vocals=true)` submits a *task* and polls it internally instead, because separating vocals is only available in the backend's async mode. You still get the saved file paths back from a single call; you just don't see the task, and — like the SFX tools — it uses the same `get_sfx_task` recovery path if the call times out. The SFX tools submit a *task*, then poll it until it completes — `text_to_sfx` and `video_to_sfx` do this for you and return the saved file paths, so you normally never see the task. `audio_ducking` uses the same submit-then-poll flow and the same `get_sfx_task` recovery path.
 
 If a call times out, the generation keeps running (and is already charged). The error message carries the task id, and `get_sfx_task("<id>")` retrieves the result once it's ready. The task id is also printed to stderr the moment a task is submitted, so it survives even a cancelled call. `get_sfx_task` is safe to call repeatedly: if the file is already on disk it reports that instead of downloading a second copy.
 
@@ -166,7 +166,7 @@ If a call times out, the generation keeps running (and is already charged). The 
 
 **Sound effects** are saved in the requested `audio_format` — `wav`, `mp3`, `flac`, or `aac` (the default, written as `.m4a`); `video_to_sfx` saves audio only, not the source video.
 
-File names come from the prompt (slugified, truncated to 80 characters). When there is no prompt to name a file after — `video_to_sfx` without one, or any file recovered via `get_sfx_task` — the name is `sfx-<first 8 chars of the task id>` instead. Existing files are never overwritten: a `-1`, `-2`, … suffix is added instead.
+File names come from the prompt (slugified, truncated to 80 characters). When there is no prompt to name a file after — `video_to_sfx` without one, or an SFX/ducking file recovered via `get_sfx_task` — the name is `sfx-<first 8 chars of the task id>` instead. A `video_to_music(isolate_vocals=true)` task recovered via `get_sfx_task` is named `music-<first 8 chars of the task id>` instead (`get_sfx_task` detects the music envelope shape and saves audio/vocals/mux the same way as a direct `video_to_music` call). Existing files are never overwritten: a `-1`, `-2`, … suffix is added instead.
 
 **Ducking** results are saved as a single file: a `.wav`, or a `.mp4` when the voice input was a video (the ducked mix is muxed back into it). The file name is the voice input's name plus `-ducked` (e.g. `interview.mp4` → `interview-ducked.mp4`), falling back to `ducked-<first 8 chars of the task id>` when there is no usable name. A ducking result recovered via `get_sfx_task` is named `sfx-<first 8 chars of the task id>` instead, since that tool has no voice file name to work from.
 
@@ -178,5 +178,5 @@ File names come from the prompt (slugified, truncated to 80 characters). When th
 | `Insufficient minutes` / `Credit limit exceeded` | Top up at <https://platform.sonilo.com/dashboard/billing>. |
 | `Rate limit exceeded` | Check `get_account_services` for your rpm/concurrency limits. |
 | `Generation timed out` (music, `text_to_music`/`video_to_music` without `isolate_vocals`) | Raise `TIME_OUT_SECONDS`. Check `get_usage` to confirm whether the backend completed and charged. |
-| `Timed out … waiting for task <id>` (SFX, ducking) | The generation is still running. Call `get_sfx_task("<id>")` to retrieve the result — nothing is lost. `video_to_music(isolate_vocals=true)` also polls a task and can time out the same way, but `get_sfx_task` does not understand its result shape — the task keeps running and is charged either way; use the task id to check `get_usage`. |
+| `Timed out … waiting for task <id>` (SFX, ducking, or `video_to_music(isolate_vocals=true)`) | The generation is still running. Call `get_sfx_task("<id>")` to retrieve the result — nothing is lost, including for a timed-out `isolate_vocals` music task (`get_sfx_task` recognizes its result shape and saves audio/vocals/mux the same way `video_to_music` itself would). |
 | `Task not found` | The task id doesn't exist, or belongs to a purely streaming generation (`text_to_music`, or `video_to_music` without `isolate_vocals`), which isn't pollable. Check the id. |

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ files. To opt out — e.g. to read a video from elsewhere on disk — set
 | Tool | Description | Cost |
 |---|---|---|
 | `text_to_music(prompt, duration, output_directory?)` | Generate music from a text prompt. | ✅ |
-| `video_to_music(video_path? \| video_url?, prompt?, output_directory?)` | Generate music matched to a video. Max duration **360s (6 min)**; subject to the account's upload-size cap (typically 300 MB). | ✅ |
+| `video_to_music(video_path? \| video_url?, prompt?, isolate_vocals?, output_directory?)` | Generate music matched to a video. Max duration **360s (6 min)**; subject to the account's upload-size cap (typically 300 MB). `isolate_vocals` (default `false`) also produces an isolated vocal stem and a ready-to-use mux; when set, the call runs the backend's async generation mode internally instead of streaming. | ✅ |
 | `text_to_sfx(prompt, duration, audio_format?, output_directory?)` | Generate a sound effect from text. Duration 1–180s; formats wav/mp3/aac/flac (default aac). | ✅ |
 | `video_to_sfx(video_path? \| video_url?, prompt?, segments?, audio_format?, output_directory?)` | Generate SFX for a video; saves the generated SFX audio. Max video duration **180s (3 min)**. | ✅ |
 | `audio_ducking(voice_path? \| voice_url?, music_path? \| music_url?, output_directory?)` | Duck a music bed under a voice track. The voice input may be a video — the ducked mix is muxed back into a new `.mp4`. Each input max **360s (6 min)**; subject to the account's upload-size cap. | ✅ |
@@ -154,13 +154,15 @@ Tools marked ✅ make API calls that incur charges on your Sonilo account.
 
 ### Sound effects and ducking run as tasks
 
-The music tools stream their result and finish in one call. The SFX tools submit a *task*, then poll it until it completes — `text_to_sfx` and `video_to_sfx` do this for you and return the saved file paths, so you normally never see the task. `audio_ducking` uses the same submit-then-poll flow and the same `get_sfx_task` recovery path.
+The music tools stream their result and finish in one call — with one exception: `video_to_music(isolate_vocals=true)` submits a *task* and polls it internally instead, the same way the SFX tools do (see below), because separating vocals is only available in the backend's async mode. You still get the saved file paths back from a single call; you just don't see the task. The SFX tools submit a *task*, then poll it until it completes — `text_to_sfx` and `video_to_sfx` do this for you and return the saved file paths, so you normally never see the task. `audio_ducking` uses the same submit-then-poll flow and the same `get_sfx_task` recovery path.
 
 If a call times out, the generation keeps running (and is already charged). The error message carries the task id, and `get_sfx_task("<id>")` retrieves the result once it's ready. The task id is also printed to stderr the moment a task is submitted, so it survives even a cancelled call. `get_sfx_task` is safe to call repeatedly: if the file is already on disk it reports that instead of downloading a second copy.
 
 ## Output Format
 
 **Music** is saved as `.m4a` (AAC in MP4 container). File names use the title returned by the backend (slugified), or a `sonilo-<timestamp>.m4a` fallback. When multiple parallel streams are returned, a `-<index>` suffix is appended.
+
+**`video_to_music(isolate_vocals=true)`** saves up to three kinds of file, each labeled in the returned text: the generated music audio (same naming as above, based on `prompt` or falling back to `music-<first 8 chars of the task id>`), the isolated vocal stem as `<base>-vocals.<ext>`, and the mux — vocals and music already mixed together, the ready-to-use combined result — as `<base>-mux.<ext>` (or `<base>-mux-<index>.<ext>` for multiple streams). The vocal stem and mux extensions come from the backend's reported `content_type` (typically `.m4a`).
 
 **Sound effects** are saved in the requested `audio_format` — `wav`, `mp3`, `flac`, or `aac` (the default, written as `.m4a`); `video_to_sfx` saves audio only, not the source video.
 
@@ -175,6 +177,6 @@ File names come from the prompt (slugified, truncated to 80 characters). When th
 | `Invalid SONILO_API_KEY` | Verify the key at <https://platform.sonilo.com/dashboard/api-keys>. |
 | `Insufficient minutes` / `Credit limit exceeded` | Top up at <https://platform.sonilo.com/dashboard/billing>. |
 | `Rate limit exceeded` | Check `get_account_services` for your rpm/concurrency limits. |
-| `Generation timed out` (music) | Raise `TIME_OUT_SECONDS`. Check `get_usage` to confirm whether the backend completed and charged. |
-| `Timed out … waiting for task <id>` (SFX) | The generation is still running. Call `get_sfx_task("<id>")` to retrieve the result — nothing is lost. |
-| `Task not found` | The task id doesn't exist (or belongs to a music task, which isn't pollable). Check the id. |
+| `Generation timed out` (music, `text_to_music`/`video_to_music` without `isolate_vocals`) | Raise `TIME_OUT_SECONDS`. Check `get_usage` to confirm whether the backend completed and charged. |
+| `Timed out … waiting for task <id>` (SFX, ducking) | The generation is still running. Call `get_sfx_task("<id>")` to retrieve the result — nothing is lost. `video_to_music(isolate_vocals=true)` also polls a task and can time out the same way, but `get_sfx_task` does not understand its result shape — the task keeps running and is charged either way; use the task id to check `get_usage`. |
+| `Task not found` | The task id doesn't exist, or belongs to a purely streaming generation (`text_to_music`, or `video_to_music` without `isolate_vocals`), which isn't pollable. Check the id. |

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["spencer-zqian"]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sonilo-mcp"
-version = "0.4.0"
+version = "0.5.0"
 description = "MCP server for Sonilo AI music generation API"
 authors = [{ name = "Sonilo", email = "support@sonilo.com" }]
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/sonilo-ai/sonilo-mcp",
     "source": "github"
   },
-  "version": "0.4.0",
+  "version": "0.5.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "sonilo-mcp",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "transport": {
         "type": "stdio"
       },

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="sonilo-mcp",
-    version="0.1.0",
+    version="0.5.0",
     package_dir={"": "src"},
     packages=find_packages(where="src"),
     include_package_data=True,

--- a/src/sonilo_mcp/api.py
+++ b/src/sonilo_mcp/api.py
@@ -420,9 +420,10 @@ def _is_task_not_found(e: BaseException) -> bool:
     where recovery advice should be omitted.
 
     Only a 404 means that: a bad/typo'd id, or an id for a task type
-    /v1/tasks does not serve. It serves SFX and audio-ducking tasks; a
-    streaming (e.g. music) generation has no task at all, so its id 404s
-    here. Every OTHER error (401, 402,
+    /v1/tasks does not serve. It serves SFX, audio-ducking, and — since
+    isolate_vocals — async video-to-music tasks; a purely streaming
+    generation (text_to_music, or video_to_music without isolate_vocals) has
+    no task at all, so its id 404s here. Every OTHER error (401, 402,
     413, 422, 429, 5xx, or a network-level failure with no status at all,
     e.g. httpx.RequestError wrapped as a bare Exception by _http_get_json)
     still refers to a task that EXISTS and was already CHARGED — the cause
@@ -988,40 +989,18 @@ def _existing_canonical_dest(
     return None
 
 
-async def _save_task_artifacts(
-    body: dict,
-    output_path: Path,
-    base_name: str,
-    task_id: str,
-    reuse_existing: bool = False,
-) -> list[TextContent]:
-    """Turn a terminal /v1/tasks/{id} body into saved local files.
+def _raise_if_task_not_succeeded(body: dict, task_id: str) -> None:
+    """Raise if a terminal task body's status isn't "succeeded".
+
+    Shared by every save-artifacts layer — SFX/ducking's
+    _save_task_artifacts and video-to-music's _save_music_task_artifacts —
+    since failure/unexpected-status handling only reads `status`, `error`,
+    and `refunded`, none of which depend on the envelope's audio/video shape.
 
     failed -> raise with the backend's error code/message and whether the
-    charge was refunded. succeeded -> download whichever artifacts the task
-    produced — audio and/or video — one TextContent per saved file. An audio
-    artifact is required: an SFX task always has audio (video-to-sfx returns
-    audio only). The sole exemption is an audio-ducking task with a video
-    voice input, whose only artifact is the re-muxed mp4 (see
-    _normalize_task_envelope, which reports whether it saw that envelope).
-
-    task_id must be the caller's own known-good id (from _post_task_submit
-    or the tool's own task_id argument), NOT derived from body — the
-    backend's terminal body is not a trustworthy source for the recovery
-    id, and a missing/incorrect id here would make a paid result
-    unrecoverable.
-
-    reuse_existing: when True (get_sfx_task's recovery path only — never
-    text_to_sfx/video_to_sfx), an artifact whose canonical unsuffixed path
-    already exists and is non-empty is treated as already downloaded rather
-    than re-fetched into a new -1/-2 suffixed file. get_sfx_task is the
-    documented recovery tool and its own messages actively invite repeat
-    calls ("still processing, try again later"), so without this, every
-    extra call after success would silently pile up duplicate downloads of
-    the same paid result. text_to_sfx/video_to_sfx must NOT set this: two
-    calls with the same prompt are two different generations and must
-    always land in two distinct files (see _artifact_dest's atomic
-    reservation), so they keep the default of False.
+    charge was refunded. Anything else non-terminal (a caller bug — _poll_task
+    only returns terminal bodies) -> raise generically. Does nothing when
+    status is "succeeded".
     """
     task_status = body.get("status")
     if task_status == "failed":
@@ -1058,6 +1037,49 @@ async def _save_task_artifacts(
             "This may be transient — check again with "
             f'get_sfx_task("{task_id}").'
         )
+
+
+async def _save_task_artifacts(
+    body: dict,
+    output_path: Path,
+    base_name: str,
+    task_id: str,
+    reuse_existing: bool = False,
+) -> list[TextContent]:
+    """Turn a terminal /v1/tasks/{id} body into saved local files.
+
+    failed -> raise with the backend's error code/message and whether the
+    charge was refunded. succeeded -> download whichever artifacts the task
+    produced — audio and/or video — one TextContent per saved file. An audio
+    artifact is required: an SFX task always has audio (video-to-sfx returns
+    audio only). The sole exemption is an audio-ducking task with a video
+    voice input, whose only artifact is the re-muxed mp4 (see
+    _normalize_task_envelope, which reports whether it saw that envelope).
+
+    task_id must be the caller's own known-good id (from _post_task_submit
+    or the tool's own task_id argument), NOT derived from body — the
+    backend's terminal body is not a trustworthy source for the recovery
+    id, and a missing/incorrect id here would make a paid result
+    unrecoverable.
+
+    reuse_existing: when True (get_sfx_task's recovery path only — never
+    text_to_sfx/video_to_sfx), an artifact whose canonical unsuffixed path
+    already exists and is non-empty is treated as already downloaded rather
+    than re-fetched into a new -1/-2 suffixed file. get_sfx_task is the
+    documented recovery tool and its own messages actively invite repeat
+    calls ("still processing, try again later"), so without this, every
+    extra call after success would silently pile up duplicate downloads of
+    the same paid result. text_to_sfx/video_to_sfx must NOT set this: two
+    calls with the same prompt are two different generations and must
+    always land in two distinct files (see _artifact_dest's atomic
+    reservation), so they keep the default of False.
+
+    This is NOT used for async (isolate_vocals) video-to-music tasks — their
+    envelope shapes `audio` as a LIST (one entry per stream_index) plus
+    optional single `vocals` and list `mux` slots, which _has_artifact/
+    _normalize_task_envelope don't model. See _save_music_task_artifacts.
+    """
+    _raise_if_task_not_succeeded(body, task_id)
 
     body, is_ducking = _normalize_task_envelope(body)
 
@@ -1181,6 +1203,116 @@ async def _save_task_artifacts(
     return saved
 
 
+# ---------- video-to-music (isolate_vocals) task pipeline ----------
+#
+# Async video-to-music (mode=async, isolate_vocals=true) shares
+# _post_task_submit/_poll_task with SFX/ducking, but its succeeded envelope
+# is a different shape: `audio` is ALWAYS a list (one entry per
+# stream_index, never a single dict), and — only with isolate_vocals — a
+# single `vocals` object and a `mux` list are also present. That shape
+# breaks _has_artifact/_normalize_task_envelope's single-dict assumptions
+# (a list `audio` is not a dict, so _has_artifact(audio) is always False),
+# so the save layer below is new rather than forcing _save_task_artifacts to
+# handle a second envelope shape.
+
+
+async def _save_music_task_artifacts(
+    body: dict,
+    output_path: Path,
+    base_name: str,
+    task_id: str,
+) -> list[TextContent]:
+    """Turn a terminal /v1/tasks/{id} body from an async (isolate_vocals)
+    video-to-music task into saved local files.
+
+    failed/unexpected status -> see _raise_if_task_not_succeeded (shared
+    with _save_task_artifacts; this part is envelope-agnostic).
+
+    succeeded -> download every entry in the `audio` list, then the single
+    `vocals` object if present, then every entry in the `mux` list if
+    present — one TextContent per saved file, each labeled so the caller can
+    tell audio/vocals/mux apart. The mux files (vocals+music already mixed)
+    are called out as the ready-to-use combined result.
+
+    Naming follows the existing streaming convention: `{base}.m4a` for a
+    single audio stream, `{base}-{idx}.m4a` when there is more than one.
+    `vocals` is saved as `{base}-vocals.{ext}`; `mux` follows the same
+    single/multi-stream pattern as audio: `{base}-mux.{ext}` or
+    `{base}-mux-{idx}.{ext}`.
+
+    task_id must be the caller's own known-good id (from _post_task_submit),
+    same rule as _save_task_artifacts — the terminal body is not a
+    trustworthy source for the recovery id.
+
+    Unlike _save_task_artifacts, this has no reuse_existing mode: video-to-
+    music (isolate_vocals or not) has no dedicated recovery tool (scope is
+    the video_to_music tool only), so there is no repeat-call path to
+    dedupe downloads for.
+    """
+    _raise_if_task_not_succeeded(body, task_id)
+
+    audio = body.get("audio")
+    valid_audio = (
+        [a for a in audio if _has_artifact(a)] if isinstance(audio, list) else []
+    )
+    if not valid_audio:
+        raise Exception(
+            "Task succeeded but no audio artifact was returned. Task id: "
+            f"{task_id}."
+        )
+
+    saved: list[TextContent] = []
+    saved_paths: list[Path] = []
+
+    async def _save_one(entry: dict, dest_base: str, label: str) -> None:
+        # Everything here can fail after the task already succeeded and was
+        # charged, so any failure must keep the task_id (and, if some files
+        # already made it to disk, list them) rather than silently drop
+        # them — mirrors _save_task_artifacts' per-artifact wrapping.
+        try:
+            ext = _ext_from_content_type(entry.get("content_type"))
+            dest = _artifact_dest(output_path, dest_base, ext)
+            await _download_artifact(entry["url"], dest)
+        except Exception as e:
+            already = (
+                " Already saved: " + ", ".join(str(p) for p in saved_paths) + "."
+                if saved_paths
+                else ""
+            )
+            raise Exception(
+                f"{_end_sentence(e)} The rest of this result is still "
+                f"stored on the backend — task id: {task_id}.{already}"
+            ) from e
+        saved_paths.append(dest)
+        saved.append(TextContent(
+            type="text", text=f"Success ({label}). File saved as: {dest}",
+        ))
+
+    multi_audio = len(valid_audio) > 1
+    for entry in sorted(valid_audio, key=lambda a: a.get("stream_index") or 0):
+        idx = entry.get("stream_index") or 0
+        suffix = f"-{idx}" if multi_audio else ""
+        await _save_one(entry, f"{base_name}{suffix}", "music audio")
+
+    vocals = body.get("vocals")
+    if _has_artifact(vocals):
+        await _save_one(vocals, f"{base_name}-vocals", "isolated vocals")
+
+    mux = body.get("mux")
+    valid_mux = [m for m in mux if _has_artifact(m)] if isinstance(mux, list) else []
+    multi_mux = len(valid_mux) > 1
+    for entry in sorted(valid_mux, key=lambda m: m.get("stream_index") or 0):
+        idx = entry.get("stream_index") or 0
+        suffix = f"-{idx}" if multi_mux else ""
+        await _save_one(
+            entry,
+            f"{base_name}-mux{suffix}",
+            "mux — vocals + music mixed, ready to use",
+        )
+
+    return saved
+
+
 # ---------- Tools: generation ----------
 
 @mcp.tool(
@@ -1268,17 +1400,30 @@ async def _get_max_upload_size_mb() -> int:
         "Maximum video duration is 360 seconds (6 minutes).\n"
         "    video_url (str, optional): HTTPS URL to a video file.\n"
         "    prompt (str, optional): Style hint for the generated music.\n"
+        "    isolate_vocals (bool, optional): Also separate an isolated "
+        "vocal stem and a ready-to-use mux (vocals+music, already mixed) "
+        "from the generated track. Defaults to False. When True this "
+        "internally uses the backend's async generation mode (submit + "
+        "poll) instead of streaming — the call takes longer but the tool "
+        "still waits for completion. Subject to the same 360-second video "
+        "duration cap as the plain case.\n"
         "    output_directory (str, optional): Where to save the resulting "
         "audio file(s). Defaults to SONILO_MCP_BASE_PATH.\n\n"
         "Exactly one of video_path and video_url must be provided.\n\n"
         "Returns:\n"
-        "    One TextContent per generated audio stream."
+        "    isolate_vocals=False (default): one TextContent per generated "
+        "audio stream, unchanged from before.\n"
+        "    isolate_vocals=True: one TextContent per generated audio "
+        "stream, plus one for the isolated vocals file, plus one per mux "
+        "stream (vocals+music mixed — this is the ready-to-use combined "
+        "result). Each TextContent's label says which kind of file it is."
     )
 )
 async def video_to_music(
     video_path: str | None = None,
     video_url: str | None = None,
     prompt: str | None = None,
+    isolate_vocals: bool = False,
     output_directory: str | None = None,
 ) -> list[TextContent]:
     if (video_path and video_url) or (not video_path and not video_url):
@@ -1308,14 +1453,26 @@ async def video_to_music(
                 f"Video file is too large ({size_mb:.1f} MB > {max_mb} MB cap)"
             )
         await _check_media_duration(str(resolved))
-        data = {"prompt": prompt} if prompt else None
+        data: dict = {"prompt": prompt} if prompt else {}
+        if isolate_vocals:
+            # isolate_vocals requires mode=async on the backend (else a
+            # 400) — always send both together, no user-facing mode param.
+            data["mode"] = "async"
+            data["isolate_vocals"] = "true"
         mime, _ = mimetypes.guess_type(resolved.name)
         content = _read_capped(resolved, max_mb, "Video")
         files = {"video": (resolved.name, content, mime or "application/octet-stream")}
+        if isolate_vocals:
+            task_id = await _post_task_submit(
+                "/v1/video-to-music", data=data, files=files
+            )
+            body = await _poll_task(task_id, cfg["timeout"])
+            base = _slugify(prompt) if prompt else f"music-{task_id[:8]}"
+            return await _save_music_task_artifacts(body, out_path, base, task_id)
         return await _post_streaming_generation(
             "/v1/video-to-music",
             out_path,
-            data=data,
+            data=data or None,
             files=files,
         )
 
@@ -1324,6 +1481,13 @@ async def video_to_music(
     form: dict = {"video_url": video_url}
     if prompt:
         form["prompt"] = prompt
+    if isolate_vocals:
+        form["mode"] = "async"
+        form["isolate_vocals"] = "true"
+        task_id = await _post_task_submit("/v1/video-to-music", data=form)
+        body = await _poll_task(task_id, cfg["timeout"])
+        base = _slugify(prompt) if prompt else f"music-{task_id[:8]}"
+        return await _save_music_task_artifacts(body, out_path, base, task_id)
     # Use `data` for form fields without files; httpx will use
     # application/x-www-form-urlencoded. The backend `video_to_music`
     # endpoint accepts both multipart and urlencoded for the URL mode.

--- a/src/sonilo_mcp/api.py
+++ b/src/sonilo_mcp/api.py
@@ -1203,6 +1203,29 @@ async def _save_task_artifacts(
     return saved
 
 
+def _is_music_task_envelope(body: dict) -> bool:
+    """Whether a terminal /v1/tasks/{id} body is an async video-to-music
+    envelope (list-shaped `audio`, optional single `vocals` and list `mux`)
+    rather than the SFX/ducking single-dict-`audio` shape.
+
+    get_sfx_task's recovery path checks this to route between
+    _save_task_artifacts (SFX/ducking) and _save_music_task_artifacts
+    (async video-to-music). Prefers the backend's own `type` field —
+    ducking bodies already carry `type: "audio_ducking"`, so video-to-music
+    carrying `type: "video_to_music"` follows the same convention — but
+    falls back to shape-sniffing (`audio` as a list, or a `vocals`/`mux`
+    key present) for a body that omits `type`, so recovery keeps working
+    even then. A failed task's body normally has none of these markers;
+    that's harmless here, since failure/refund handling
+    (_raise_if_task_not_succeeded) is identical on both routes.
+    """
+    if body.get("type") == "video_to_music":
+        return True
+    if isinstance(body.get("audio"), list):
+        return True
+    return "vocals" in body or "mux" in body
+
+
 # ---------- video-to-music (isolate_vocals) task pipeline ----------
 #
 # Async video-to-music (mode=async, isolate_vocals=true) shares
@@ -1645,11 +1668,13 @@ async def video_to_sfx(
 
 @mcp.tool(
     description=(
-        "Check a sound-effects or audio-ducking generation task and, if "
-        "finished, download its result file(s). Use this to recover a "
-        "result when text_to_sfx, video_to_sfx, or audio_ducking timed out "
-        "— their error message contains the task_id. Does not poll: a "
-        "single status check per call. This tool itself never charges.\n\n"
+        "Check a sound-effects, audio-ducking, or async video-to-music "
+        "(isolate_vocals) generation task and, if finished, download its "
+        "result file(s). Use this to recover a result when text_to_sfx, "
+        "video_to_sfx, audio_ducking, or video_to_music(isolate_vocals=true) "
+        "timed out — their error message contains the task_id. Does not "
+        "poll: a single status check per call. This tool itself never "
+        "charges.\n\n"
         "Args:\n"
         "    task_id (str): The task id returned in the timeout message.\n"
         "    output_directory (str, optional): Where to save result files. "
@@ -1658,8 +1683,10 @@ async def video_to_sfx(
         "    Still processing -> a status message; try again later. "
         "Succeeded -> the saved file path(s): audio, plus video for "
         "video_to_sfx tasks; a single .wav or .mp4 for audio_ducking "
-        "tasks. Failed -> an error including whether the charge was "
-        "refunded."
+        "tasks; for a video_to_music(isolate_vocals=true) task, the audio "
+        "stream(s) plus the isolated vocals stem plus the mux "
+        "(vocals+music mixed — the ready-to-use combined result). "
+        "Failed -> an error including whether the charge was refunded."
     )
 )
 async def get_sfx_task(
@@ -1707,6 +1734,19 @@ async def get_sfx_task(
     out_path = _make_output_path(output_directory)
     # No prompt available on recovery — name by task id; extension comes
     # from the envelope's content_type.
+    if _is_music_task_envelope(body):
+        # Async (isolate_vocals) video-to-music: list-shaped `audio` plus
+        # optional `vocals`/`mux` — needs the music-aware save layer, not
+        # _save_task_artifacts's single-dict-audio assumption. No
+        # reuse_existing here: _save_music_task_artifacts doesn't support it
+        # (see its docstring — video-to-music has no dedicated recovery
+        # tool of its own to dedupe repeat calls for), so a second
+        # get_sfx_task call on an already-recovered music task lands in
+        # freshly -1/-2-suffixed files rather than being detected as a
+        # duplicate.
+        return await _save_music_task_artifacts(
+            body, out_path, f"music-{task_id[:8]}", task_id
+        )
     return await _save_task_artifacts(
         body, out_path, f"sfx-{task_id[:8]}", task_id, reuse_existing=True
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3471,6 +3471,96 @@ async def test_get_sfx_task_recovers_ducking_task(monkeypatch, output_dir):
     assert str(saved) in result[0].text
 
 
+@respx.mock
+async def test_get_sfx_task_recovers_isolate_vocals_music_task(monkeypatch, output_dir):
+    # /v1/tasks also serves async (isolate_vocals) video-to-music tasks now.
+    # Their envelope shapes `audio` as a LIST plus optional `vocals`/`mux` —
+    # get_sfx_task must detect that shape and route to
+    # _save_music_task_artifacts instead of the SFX/ducking single-dict
+    # _save_task_artifacts path (which would otherwise wrongly report "no
+    # audio artifact was returned").
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    respx.get("https://api.test.local/v1/tasks/m-vocals-99").mock(
+        return_value=httpx.Response(200, json={
+            "task_id": "m-vocals-99", "type": "video_to_music",
+            "status": "succeeded",
+            "audio": [{
+                "stream_index": 0, "url": "https://r2.test/a.m4a",
+                "content_type": "audio/mp4", "file_size": 1,
+            }],
+            "vocals": {
+                "url": "https://r2.test/vocals.m4a",
+                "content_type": "audio/mp4", "file_size": 1,
+            },
+            "mux": [{
+                "stream_index": 0, "url": "https://r2.test/mux.m4a",
+                "content_type": "audio/mp4", "file_size": 1,
+            }],
+        })
+    )
+    respx.get("https://r2.test/a.m4a").mock(return_value=httpx.Response(200, content=b"a"))
+    respx.get("https://r2.test/vocals.m4a").mock(return_value=httpx.Response(200, content=b"v"))
+    respx.get("https://r2.test/mux.m4a").mock(return_value=httpx.Response(200, content=b"m"))
+    from sonilo_mcp.api import get_sfx_task
+    result = await get_sfx_task("m-vocals-99")
+    assert (output_dir / "music-m-vocals.m4a").read_bytes() == b"a"
+    assert (output_dir / "music-m-vocals-vocals.m4a").read_bytes() == b"v"
+    assert (output_dir / "music-m-vocals-mux.m4a").read_bytes() == b"m"
+    assert len(result) == 3
+    texts = [t.text for t in result]
+    assert any("music audio" in t for t in texts)
+    assert any("vocals" in t.lower() for t in texts)
+    assert any("ready to use" in t.lower() for t in texts)
+
+
+@respx.mock
+async def test_get_sfx_task_recovers_music_task_without_type_field(
+    monkeypatch, output_dir
+):
+    # Detection must not rely solely on `type` — fall back to shape-sniffing
+    # (a list-shaped `audio`) so recovery still works if the backend ever
+    # omits `type`.
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    respx.get("https://api.test.local/v1/tasks/m-notype-1").mock(
+        return_value=httpx.Response(200, json={
+            "task_id": "m-notype-1", "status": "succeeded",
+            "audio": [{
+                "stream_index": 0, "url": "https://r2.test/a2.m4a",
+                "content_type": "audio/mp4", "file_size": 1,
+            }],
+        })
+    )
+    respx.get("https://r2.test/a2.m4a").mock(return_value=httpx.Response(200, content=b"aa"))
+    from sonilo_mcp.api import get_sfx_task
+    result = await get_sfx_task("m-notype-1")
+    assert (output_dir / "music-m-notype.m4a").read_bytes() == b"aa"
+    assert len(result) == 1
+
+
+@respx.mock
+async def test_get_sfx_task_music_task_failed_still_reports_refund(
+    monkeypatch, output_dir
+):
+    # A failed music task must raise the same shared failure/refund message
+    # as SFX/ducking, task_id included — envelope detection must not change
+    # failure handling.
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    respx.get("https://api.test.local/v1/tasks/m-failed-1").mock(
+        return_value=httpx.Response(200, json={
+            "task_id": "m-failed-1", "type": "video_to_music",
+            "status": "failed",
+            "error": {"code": "GENERATION_FAILED", "message": "boom"},
+            "refunded": False,
+        })
+    )
+    from sonilo_mcp.api import get_sfx_task
+    with pytest.raises(Exception, match="boom"):
+        await get_sfx_task("m-failed-1")
+
+
 # ---------- audio_ducking ----------
 
 async def test_audio_ducking_requires_exactly_one_voice_input(output_dir):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1250,6 +1250,304 @@ async def test_video_to_music_path_too_long(monkeypatch, output_dir, tmp_path):
     assert upload_route.call_count == 0
 
 
+@respx.mock
+async def test_video_to_music_isolate_vocals_url_mode_submits_async_fields(
+    monkeypatch, output_dir
+):
+    # isolate_vocals=True must route through the task submit+poll path (mode
+    # async), sending both mode and isolate_vocals as form fields, instead of
+    # the plain streaming POST.
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    from sonilo_mcp import api
+
+    async def no_sleep(s):
+        pass
+
+    monkeypatch.setattr(api, "_poll_sleep", no_sleep)
+    submit = respx.post("https://api.test.local/v1/video-to-music").mock(
+        return_value=httpx.Response(
+            202, json={"task_id": "t-vocals-1", "status": "processing"}
+        )
+    )
+    respx.get("https://api.test.local/v1/tasks/t-vocals-1").mock(
+        return_value=httpx.Response(200, json={
+            "task_id": "t-vocals-1", "status": "succeeded",
+            "audio": [{
+                "stream_index": 0, "url": "https://r2.test/a.m4a",
+                "content_type": "audio/mp4", "sample_rate": 44100,
+                "channels": 2, "file_size": 5,
+            }],
+        })
+    )
+    respx.get("https://r2.test/a.m4a").mock(
+        return_value=httpx.Response(200, content=b"audio")
+    )
+    result = await api.video_to_music(
+        video_url="https://cdn.example.com/v.mp4",
+        prompt="Chill Beat",
+        isolate_vocals=True,
+    )
+    from urllib.parse import parse_qs
+    sent = parse_qs(submit.calls.last.request.content.decode())
+    assert sent["mode"] == ["async"]
+    assert sent["isolate_vocals"] == ["true"]
+    assert sent["video_url"] == ["https://cdn.example.com/v.mp4"]
+    assert sent["prompt"] == ["Chill Beat"]
+    assert len(result) == 1
+    assert (output_dir / "chill-beat.m4a").read_bytes() == b"audio"
+
+
+@respx.mock
+async def test_video_to_music_isolate_vocals_false_no_extra_fields(
+    monkeypatch, output_dir
+):
+    # Default isolate_vocals=False must keep streaming behavior UNCHANGED —
+    # no mode/isolate_vocals fields sent, no task_id round trip.
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    ndjson = _ndjson_bytes([
+        {"type": "audio_chunk", "stream_index": 0, "num_streams": 1,
+         "data": base64.b64encode(b"x").decode()},
+        {"type": "complete"},
+    ])
+    route = respx.post("https://api.test.local/v1/video-to-music").mock(
+        return_value=httpx.Response(200, content=ndjson)
+    )
+    from sonilo_mcp.api import video_to_music
+    await video_to_music(video_url="https://cdn.example.com/v.mp4")
+    from urllib.parse import parse_qs
+    sent = parse_qs(route.calls.last.request.content.decode())
+    assert "mode" not in sent
+    assert "isolate_vocals" not in sent
+
+
+@respx.mock
+async def test_video_to_music_isolate_vocals_path_mode_multipart(
+    monkeypatch, output_dir, tmp_path
+):
+    # Local-file (multipart) submission must also carry mode/isolate_vocals
+    # as form fields alongside the uploaded video.
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    from sonilo_mcp import api
+    _patch_ffprobe(monkeypatch, duration=60.0)
+
+    async def no_sleep(s):
+        pass
+
+    monkeypatch.setattr(api, "_poll_sleep", no_sleep)
+    respx.get("https://api.test.local/v1/account/services").mock(
+        return_value=httpx.Response(200, json={"max_upload_size_mb": 300})
+    )
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"FAKE-MP4")
+    submit = respx.post("https://api.test.local/v1/video-to-music").mock(
+        return_value=httpx.Response(
+            202, json={"task_id": "t-vocals-2", "status": "processing"}
+        )
+    )
+    respx.get("https://api.test.local/v1/tasks/t-vocals-2").mock(
+        return_value=httpx.Response(200, json={
+            "task_id": "t-vocals-2", "status": "succeeded",
+            "audio": [{
+                "stream_index": 0, "url": "https://r2.test/a.m4a",
+                "content_type": "audio/mp4", "file_size": 1,
+            }],
+        })
+    )
+    respx.get("https://r2.test/a.m4a").mock(
+        return_value=httpx.Response(200, content=b"a")
+    )
+    api._reset_services_cache()
+    result = await api.video_to_music(video_path=str(video), isolate_vocals=True)
+    sent = submit.calls.last.request
+    assert sent.headers["content-type"].startswith("multipart/form-data")
+    assert b"FAKE-MP4" in sent.content
+    assert b'name="mode"' in sent.content and b"async" in sent.content
+    assert b'name="isolate_vocals"' in sent.content
+    assert len(result) == 1
+    assert (output_dir / "music-t-vocals.m4a").exists()
+
+
+@respx.mock
+async def test_video_to_music_isolate_vocals_saves_audio_vocals_and_mux(
+    monkeypatch, output_dir
+):
+    # Full succeeded envelope with multi-stream audio, a single vocals stem,
+    # and multi-stream mux — must save all of them under the documented
+    # naming convention and label each in the returned TextContent.
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    from sonilo_mcp import api
+
+    async def no_sleep(s):
+        pass
+
+    monkeypatch.setattr(api, "_poll_sleep", no_sleep)
+    respx.post("https://api.test.local/v1/video-to-music").mock(
+        return_value=httpx.Response(
+            202, json={"task_id": "t-vocals-3", "status": "processing"}
+        )
+    )
+    respx.get("https://api.test.local/v1/tasks/t-vocals-3").mock(
+        return_value=httpx.Response(200, json={
+            "task_id": "t-vocals-3", "type": "video_to_music",
+            "status": "succeeded",
+            "audio": [
+                {"stream_index": 0, "url": "https://r2.test/a0.m4a",
+                 "content_type": "audio/mp4", "file_size": 2},
+                {"stream_index": 1, "url": "https://r2.test/a1.m4a",
+                 "content_type": "audio/mp4", "file_size": 2},
+            ],
+            "vocals": {
+                "url": "https://r2.test/vocals.m4a",
+                "content_type": "audio/mp4", "file_size": 3,
+            },
+            "mux": [
+                {"stream_index": 0, "url": "https://r2.test/mux0.m4a",
+                 "content_type": "audio/mp4", "file_size": 4},
+                {"stream_index": 1, "url": "https://r2.test/mux1.m4a",
+                 "content_type": "audio/mp4", "file_size": 4},
+            ],
+            "title": {"title": "Beat Drop", "summary": "s", "display_tags": []},
+            "duration_seconds": 92.5,
+        })
+    )
+    respx.get("https://r2.test/a0.m4a").mock(return_value=httpx.Response(200, content=b"a0"))
+    respx.get("https://r2.test/a1.m4a").mock(return_value=httpx.Response(200, content=b"a1"))
+    respx.get("https://r2.test/vocals.m4a").mock(return_value=httpx.Response(200, content=b"voc"))
+    respx.get("https://r2.test/mux0.m4a").mock(return_value=httpx.Response(200, content=b"mx0"))
+    respx.get("https://r2.test/mux1.m4a").mock(return_value=httpx.Response(200, content=b"mx1"))
+
+    result = await api.video_to_music(
+        video_url="https://cdn.example.com/v.mp4",
+        prompt="Beat Drop",
+        isolate_vocals=True,
+    )
+
+    assert (output_dir / "beat-drop-0.m4a").read_bytes() == b"a0"
+    assert (output_dir / "beat-drop-1.m4a").read_bytes() == b"a1"
+    assert (output_dir / "beat-drop-vocals.m4a").read_bytes() == b"voc"
+    assert (output_dir / "beat-drop-mux-0.m4a").read_bytes() == b"mx0"
+    assert (output_dir / "beat-drop-mux-1.m4a").read_bytes() == b"mx1"
+
+    assert len(result) == 5
+    texts = [t.text for t in result]
+    assert any("music audio" in t and "beat-drop-0.m4a" in t for t in texts)
+    assert any("music audio" in t and "beat-drop-1.m4a" in t for t in texts)
+    assert any("vocals" in t.lower() and "beat-drop-vocals.m4a" in t for t in texts)
+    mux_texts = [t for t in texts if "beat-drop-mux-0.m4a" in t or "beat-drop-mux-1.m4a" in t]
+    assert len(mux_texts) == 2
+    assert all("mux" in t.lower() and "ready to use" in t.lower() for t in mux_texts)
+
+
+@respx.mock
+async def test_video_to_music_isolate_vocals_single_stream_no_suffix(
+    monkeypatch, output_dir
+):
+    # A single audio stream / single mux stream must use the unsuffixed
+    # {base}.m4a / {base}-mux.m4a naming (matches the streaming convention's
+    # num_streams == 1 case).
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    from sonilo_mcp import api
+
+    async def no_sleep(s):
+        pass
+
+    monkeypatch.setattr(api, "_poll_sleep", no_sleep)
+    respx.post("https://api.test.local/v1/video-to-music").mock(
+        return_value=httpx.Response(
+            202, json={"task_id": "t-vocals-4", "status": "processing"}
+        )
+    )
+    respx.get("https://api.test.local/v1/tasks/t-vocals-4").mock(
+        return_value=httpx.Response(200, json={
+            "task_id": "t-vocals-4", "status": "succeeded",
+            "audio": [{
+                "stream_index": 0, "url": "https://r2.test/a.m4a",
+                "content_type": "audio/mp4", "file_size": 1,
+            }],
+            "vocals": {
+                "url": "https://r2.test/vocals.m4a",
+                "content_type": "audio/mp4", "file_size": 1,
+            },
+            "mux": [{
+                "stream_index": 0, "url": "https://r2.test/mux.m4a",
+                "content_type": "audio/mp4", "file_size": 1,
+            }],
+        })
+    )
+    respx.get("https://r2.test/a.m4a").mock(return_value=httpx.Response(200, content=b"a"))
+    respx.get("https://r2.test/vocals.m4a").mock(return_value=httpx.Response(200, content=b"v"))
+    respx.get("https://r2.test/mux.m4a").mock(return_value=httpx.Response(200, content=b"m"))
+
+    await api.video_to_music(
+        video_url="https://cdn.example.com/v.mp4", isolate_vocals=True
+    )
+    assert (output_dir / "music-t-vocals.m4a").read_bytes() == b"a"
+    assert (output_dir / "music-t-vocals-vocals.m4a").read_bytes() == b"v"
+    assert (output_dir / "music-t-vocals-mux.m4a").read_bytes() == b"m"
+
+
+@respx.mock
+async def test_video_to_music_isolate_vocals_task_failed(monkeypatch, output_dir):
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    from sonilo_mcp import api
+
+    async def no_sleep(s):
+        pass
+
+    monkeypatch.setattr(api, "_poll_sleep", no_sleep)
+    respx.post("https://api.test.local/v1/video-to-music").mock(
+        return_value=httpx.Response(
+            202, json={"task_id": "t-vocals-5", "status": "processing"}
+        )
+    )
+    respx.get("https://api.test.local/v1/tasks/t-vocals-5").mock(
+        return_value=httpx.Response(200, json={
+            "task_id": "t-vocals-5", "status": "failed",
+            "error": {"code": "GENERATION_FAILED", "message": "boom"},
+            "refunded": True,
+        })
+    )
+    with pytest.raises(Exception, match="boom"):
+        await api.video_to_music(
+            video_url="https://cdn.example.com/v.mp4", isolate_vocals=True
+        )
+
+
+@respx.mock
+async def test_video_to_music_isolate_vocals_no_audio_raises(monkeypatch, output_dir):
+    # Contract says `audio` is ALWAYS a list for async v2m — an empty/missing
+    # list is a backend contract violation and must raise clearly rather
+    # than silently report zero files saved.
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    from sonilo_mcp import api
+
+    async def no_sleep(s):
+        pass
+
+    monkeypatch.setattr(api, "_poll_sleep", no_sleep)
+    respx.post("https://api.test.local/v1/video-to-music").mock(
+        return_value=httpx.Response(
+            202, json={"task_id": "t-vocals-6", "status": "processing"}
+        )
+    )
+    respx.get("https://api.test.local/v1/tasks/t-vocals-6").mock(
+        return_value=httpx.Response(200, json={
+            "task_id": "t-vocals-6", "status": "succeeded", "audio": [],
+        })
+    )
+    with pytest.raises(Exception, match="no audio artifact"):
+        await api.video_to_music(
+            video_url="https://cdn.example.com/v.mp4", isolate_vocals=True
+        )
+
+
 async def test_play_audio_rejects_nonexistent(monkeypatch):
     monkeypatch.setenv("SONILO_MCP_BASE_PATH", "/tmp")
     from sonilo_mcp.api import play_audio


### PR DESCRIPTION
Adds vocal-isolation support to the `video_to_music` tool, mirroring the backend's new `isolate_vocals` flag.

## What
- `video_to_music(..., isolate_vocals=False)`. When `True`, the tool submits `mode=async` + `isolate_vocals=true`, polls the task, and saves the results; `isolate_vocals=False` streams exactly as before (request body unchanged).
- New `_save_music_task_artifacts`: saves the music `audio` list, the `vocals` stem, and the `mux` (vocals+music mixed) streams, with labeled output. File naming: `{base}.m4a` / `{base}-{idx}.m4a`, `{base}-vocals.{ext}`, `{base}-mux[-{idx}].{ext}`.
- `get_sfx_task` now also recovers timed-out `isolate_vocals` (async video-to-music) tasks — detects the music envelope and routes to the music save path; SFX/ducking recovery unchanged.

## Notes
- Adds `glama.json` (Glama registry manifest).
- README updated (tool table, output format, error/recovery notes); version bumped to 0.5.0.
- Tests: 223 passing.
- The fal upstream URL change is backend-internal and needs no MCP change.