### PR TITLE
feat: video-to-video tools + v2m ducking/preserve_speech/output_format (incl. isolate_vocals)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sonilo-mcp"
-version = "0.5.0"
+version = "0.6.0"
 description = "MCP server for Sonilo AI music generation API"
 authors = [{ name = "Sonilo", email = "support@sonilo.com" }]
 readme = "README.md"

--- a/src/sonilo_mcp/api.py
+++ b/src/sonilo_mcp/api.py
@@ -1052,9 +1052,12 @@ async def _save_task_artifacts(
     charge was refunded. succeeded -> download whichever artifacts the task
     produced — audio and/or video — one TextContent per saved file. An audio
     artifact is required: an SFX task always has audio (video-to-sfx returns
-    audio only). The sole exemption is an audio-ducking task with a video
-    voice input, whose only artifact is the re-muxed mp4 (see
-    _normalize_task_envelope, which reports whether it saw that envelope).
+    audio only). There are two exemptions: an audio-ducking task with a
+    video voice input, whose only artifact is the re-muxed mp4 (see
+    _normalize_task_envelope, which reports whether it saw that envelope);
+    and a video-to-video task (video_to_video_music/_sfx), whose only
+    artifact is the generated video with the new audio muxed in (see
+    _is_video_to_video_envelope).
 
     task_id must be the caller's own known-good id (from _post_task_submit
     or the tool's own task_id argument), NOT derived from body — the
@@ -1085,18 +1088,21 @@ async def _save_task_artifacts(
 
     audio = body.get("audio")
     video = body.get("video")
-    # An audio artifact is required, with exactly one exemption: a ducking
-    # task whose voice input was a video renders a single artifact, the
-    # re-muxed mp4, and has no audio slot at all. The exemption is keyed off
-    # _normalize_task_envelope having recognized a ducking envelope — NOT off
-    # "some artifact is present". An SFX body is still held to the audio
-    # requirement even when it carries a video: a video-without-audio SFX
-    # result means the audio half of an already-charged generation went
-    # missing, and quietly downloading just the mp4 would report success
-    # while losing it, with no recovery hint. Raising here keeps the task_id
-    # and the get_sfx_task call in the user's hands, which is the only way a
-    # paid result stays recoverable from the error message alone.
-    if not _has_artifact(audio) and not (is_ducking and _has_artifact(video)):
+    # An audio artifact is required, with exactly two exemptions: a ducking
+    # task whose voice input was a video, and a video-to-video task — both
+    # render a single artifact, the (re-)muxed mp4, and have no audio slot
+    # at all. Each exemption is keyed off its own recognizer having
+    # positively identified that envelope (_normalize_task_envelope's
+    # is_ducking / _is_video_to_video_envelope) — NOT off "some artifact is
+    # present". An SFX body is still held to the audio requirement even when
+    # it carries a video: a video-without-audio SFX result means the audio
+    # half of an already-charged generation went missing, and quietly
+    # downloading just the mp4 would report success while losing it, with no
+    # recovery hint. Raising here keeps the task_id and the get_sfx_task call
+    # in the user's hands, which is the only way a paid result stays
+    # recoverable from the error message alone.
+    is_v2v = _is_video_to_video_envelope(body)
+    if not _has_artifact(audio) and not ((is_ducking or is_v2v) and _has_artifact(video)):
         # Distinguish an unrecognized-output_type ducking result from a genuine
         # missing artifact. When there is a usable output_url but the
         # output_type is not one _normalize_task_envelope handles, get_sfx_task
@@ -1203,6 +1209,29 @@ async def _save_task_artifacts(
     return saved
 
 
+def _is_video_to_video_envelope(body: dict) -> bool:
+    """Whether a terminal /v1/tasks/{id} body is a video-to-video result:
+    a single `video` object and no `audio`. Prefers the backend `type`
+    field, falling back to shape-sniffing only for bodies that omit `type`
+    entirely.
+
+    An explicit, different `type` (e.g. "video_to_sfx", "audio_ducking") is
+    always authoritative and short-circuits straight to False: the backend's
+    /v1/tasks/{id} always sets `type` (see routers/v1/tasks.py), so shape-
+    sniffing over an explicitly-typed body would misclassify a genuine
+    video-only-without-audio SFX failure (audio half of a paid result went
+    missing — see _save_task_artifacts) as a healthy video-to-video result.
+    Ducking's normalized envelope is also excluded this way, though it is
+    additionally distinguishable by shape: it keeps its `output_url` key
+    even after _normalize_task_envelope adds the `video` slot, while a real
+    video-to-video body never has one.
+    """
+    t = body.get("type")
+    if isinstance(t, str) and t:
+        return t in ("video_to_video_music", "video_to_video_sfx")
+    return bool(body.get("video")) and body.get("audio") is None and "output_url" not in body
+
+
 def _is_music_task_envelope(body: dict) -> bool:
     """Whether a terminal /v1/tasks/{id} body is an async video-to-music
     envelope (list-shaped `audio`, optional single `vocals` and list `mux`)
@@ -1253,15 +1282,19 @@ async def _save_music_task_artifacts(
 
     succeeded -> download every entry in the `audio` list, then the single
     `vocals` object if present, then every entry in the `mux` list if
-    present — one TextContent per saved file, each labeled so the caller can
-    tell audio/vocals/mux apart. The mux files (vocals+music already mixed)
-    are called out as the ready-to-use combined result.
+    present, then every entry in the `ducked` list if present — one
+    TextContent per saved file, each labeled so the caller can tell audio/
+    vocals/mux/ducked apart. The mux files (vocals+music already mixed) are
+    called out as the ready-to-use combined result; `ducked` files are the
+    generated music lowered under the source voice (free, best-effort —
+    present only when the backend's `ducking` option ran).
 
     Naming follows the existing streaming convention: `{base}.m4a` for a
     single audio stream, `{base}-{idx}.m4a` when there is more than one.
-    `vocals` is saved as `{base}-vocals.{ext}`; `mux` follows the same
-    single/multi-stream pattern as audio: `{base}-mux.{ext}` or
-    `{base}-mux-{idx}.{ext}`.
+    `vocals` is saved as `{base}-vocals.{ext}`; `mux` and `ducked` follow
+    the same single/multi-stream pattern as audio: `{base}-mux.{ext}` or
+    `{base}-mux-{idx}.{ext}`, and likewise `{base}-ducked.{ext}` /
+    `{base}-ducked-{idx}.{ext}`.
 
     task_id must be the caller's own known-good id (from _post_task_submit),
     same rule as _save_task_artifacts — the terminal body is not a
@@ -1331,6 +1364,20 @@ async def _save_music_task_artifacts(
             entry,
             f"{base_name}-mux{suffix}",
             "mux — vocals + music mixed, ready to use",
+        )
+
+    ducked = body.get("ducked")
+    valid_ducked = (
+        [d for d in ducked if _has_artifact(d)] if isinstance(ducked, list) else []
+    )
+    multi_ducked = len(valid_ducked) > 1
+    for entry in sorted(valid_ducked, key=lambda d: d.get("stream_index") or 0):
+        idx = entry.get("stream_index") or 0
+        suffix = f"-{idx}" if multi_ducked else ""
+        await _save_one(
+            entry,
+            f"{base_name}-ducked{suffix}",
+            "ducked — music lowered under the source voice",
         )
 
     return saved

--- a/src/sonilo_mcp/api.py
+++ b/src/sonilo_mcp/api.py
@@ -1397,27 +1397,46 @@ async def _save_music_task_artifacts(
         "    prompt (str): Description of the music to generate "
         "(1–1000 chars).\n"
         "    duration (int): Length in seconds (1–360).\n"
+        "    output_format (str, optional): 'm4a' (default) or 'wav'. "
+        "'wav' requires the backend's async generation mode (submit + "
+        "poll) instead of streaming — selected automatically, no "
+        "user-facing mode param needed.\n"
         "    output_directory (str, optional): Absolute path, or relative "
         "to SONILO_MCP_BASE_PATH. Defaults to SONILO_MCP_BASE_PATH "
         "(~/Desktop unless overridden).\n\n"
         "Returns:\n"
         "    One TextContent per generated audio stream, each containing "
-        "the absolute path of the saved .m4a file (AAC in MP4 container)."
+        "the absolute path of the saved audio file (.m4a by default, "
+        ".wav when output_format='wav')."
     )
 )
 async def text_to_music(
     prompt: str,
     duration: int,
+    output_format: str | None = None,
     output_directory: str | None = None,
 ) -> list[TextContent]:
     out_path = _make_output_path(output_directory)
     # The backend's text-to-music endpoint expects form fields, not a JSON
     # body (same as video-to-music). Sending JSON yields a 422
     # "Field required" for prompt/duration.
+    data: dict = {"prompt": prompt, "duration": duration}
+    if output_format == "wav":
+        # 'wav' requires mode=async on the backend (else a 400) — always
+        # send both together, no user-facing mode param (mirrors
+        # video_to_music's isolate_vocals/preserve_speech/ducking handling).
+        data["mode"] = "async"
+        data["output_format"] = output_format
+        task_id = await _post_task_submit("/v1/text-to-music", data=data)
+        body = await _poll_task(task_id, _get_config()["timeout"])
+        base = _slugify(prompt) if prompt else f"music-{task_id[:8]}"
+        return await _save_music_task_artifacts(body, out_path, base, task_id)
+    if output_format:
+        data["output_format"] = output_format
     return await _post_streaming_generation(
         "/v1/text-to-music",
         out_path,
-        data={"prompt": prompt, "duration": duration},
+        data=data,
     )
 
 
@@ -1472,21 +1491,34 @@ async def _get_max_upload_size_mb() -> int:
         "    prompt (str, optional): Style hint for the generated music.\n"
         "    isolate_vocals (bool, optional): Also separate an isolated "
         "vocal stem and a ready-to-use mux (vocals+music, already mixed) "
-        "from the generated track. Defaults to False. When True this "
-        "internally uses the backend's async generation mode (submit + "
-        "poll) instead of streaming — the call takes longer but the tool "
-        "still waits for completion. Subject to the same 360-second video "
-        "duration cap as the plain case.\n"
+        "from the generated track. Deprecated alias for preserve_speech; "
+        "both are accepted and OR'd together. Defaults to False.\n"
+        "    preserve_speech (bool, optional): Keep the source speech in "
+        "the output alongside isolating a vocal stem and mux, same effect "
+        "as isolate_vocals. Defaults to False.\n"
+        "    output_format (str, optional): 'm4a' (default) or 'wav'.\n"
+        "    ducking (bool, optional): Duck the generated music under the "
+        "source voice at finalize time. Default-ON server-side: leave "
+        "unset to keep it on, pass False to opt out. Free, best-effort.\n"
+        "    Any of isolate_vocals/preserve_speech/output_format='wav'/"
+        "ducking makes this tool internally use the backend's async "
+        "generation mode (submit + poll) instead of streaming — the call "
+        "takes longer but the tool still waits for completion. Subject to "
+        "the same 360-second video duration cap as the plain case.\n"
         "    output_directory (str, optional): Where to save the resulting "
         "audio file(s). Defaults to SONILO_MCP_BASE_PATH.\n\n"
         "Exactly one of video_path and video_url must be provided.\n\n"
         "Returns:\n"
-        "    isolate_vocals=False (default): one TextContent per generated "
-        "audio stream, unchanged from before.\n"
-        "    isolate_vocals=True: one TextContent per generated audio "
-        "stream, plus one for the isolated vocals file, plus one per mux "
-        "stream (vocals+music mixed — this is the ready-to-use combined "
-        "result). Each TextContent's label says which kind of file it is."
+        "    Plain case (no async-triggering param set): one TextContent "
+        "per generated audio stream, unchanged from before.\n"
+        "    isolate_vocals/preserve_speech=True: one TextContent per "
+        "generated audio stream, plus one for the isolated vocals file, "
+        "plus one per mux stream (vocals+music mixed — this is the "
+        "ready-to-use combined result).\n"
+        "    ducking (default-on in async mode): also one TextContent per "
+        "ducked stream (music lowered under the source voice), when the "
+        "backend rendered one.\n"
+        "    Each TextContent's label says which kind of file it is."
     )
 )
 async def video_to_music(
@@ -1494,6 +1526,9 @@ async def video_to_music(
     video_url: str | None = None,
     prompt: str | None = None,
     isolate_vocals: bool = False,
+    preserve_speech: bool = False,
+    output_format: str | None = None,
+    ducking: bool | None = None,
     output_directory: str | None = None,
 ) -> list[TextContent]:
     if (video_path and video_url) or (not video_path and not video_url):
@@ -1508,6 +1543,16 @@ async def video_to_music(
 
     out_path = _make_output_path(output_directory)
     cfg = _get_config()
+
+    # isolate_vocals/preserve_speech/ducking/output_format="wav" all
+    # require mode=async on the backend (else a 400) — always send it
+    # together, no user-facing mode param.
+    use_async = (
+        isolate_vocals
+        or preserve_speech
+        or output_format == "wav"
+        or ducking is not None
+    )
 
     if video_path:
         resolved = _resolve_input_file(
@@ -1525,14 +1570,19 @@ async def video_to_music(
         await _check_media_duration(str(resolved))
         data: dict = {"prompt": prompt} if prompt else {}
         if isolate_vocals:
-            # isolate_vocals requires mode=async on the backend (else a
-            # 400) — always send both together, no user-facing mode param.
-            data["mode"] = "async"
             data["isolate_vocals"] = "true"
+        if preserve_speech:
+            data["preserve_speech"] = "true"
+        if output_format:
+            data["output_format"] = output_format
+        if ducking is not None:
+            data["ducking"] = "true" if ducking else "false"
+        if use_async:
+            data["mode"] = "async"
         mime, _ = mimetypes.guess_type(resolved.name)
         content = _read_capped(resolved, max_mb, "Video")
         files = {"video": (resolved.name, content, mime or "application/octet-stream")}
-        if isolate_vocals:
+        if use_async:
             task_id = await _post_task_submit(
                 "/v1/video-to-music", data=data, files=files
             )
@@ -1552,8 +1602,15 @@ async def video_to_music(
     if prompt:
         form["prompt"] = prompt
     if isolate_vocals:
-        form["mode"] = "async"
         form["isolate_vocals"] = "true"
+    if preserve_speech:
+        form["preserve_speech"] = "true"
+    if output_format:
+        form["output_format"] = output_format
+    if ducking is not None:
+        form["ducking"] = "true" if ducking else "false"
+    if use_async:
+        form["mode"] = "async"
         task_id = await _post_task_submit("/v1/video-to-music", data=form)
         body = await _poll_task(task_id, cfg["timeout"])
         base = _slugify(prompt) if prompt else f"music-{task_id[:8]}"

--- a/src/sonilo_mcp/api.py
+++ b/src/sonilo_mcp/api.py
@@ -1713,15 +1713,206 @@ async def video_to_sfx(
     return await _save_task_artifacts(body, out_path, base, task_id)
 
 
+# ---------- Tools: video-to-video ----------
+
 @mcp.tool(
     description=(
-        "Check a sound-effects, audio-ducking, or async video-to-music "
-        "(isolate_vocals) generation task and, if finished, download its "
-        "result file(s). Use this to recover a result when text_to_sfx, "
-        "video_to_sfx, audio_ducking, or video_to_music(isolate_vocals=true) "
-        "timed out — their error message contains the task_id. Does not "
-        "poll: a single status check per call. This tool itself never "
-        "charges.\n\n"
+        "Generate an original score for a video and return a NEW VIDEO with "
+        "the music muxed in (not just an audio file). Provide either a local "
+        "video path or a public video URL. Generation is asynchronous; this "
+        "tool waits for completion and returns the saved video path. Tracks "
+        "are fully licensed (via Shutterstock) and cleared for commercial "
+        "use.\n\n"
+        "⚠️ COST WARNING: This tool makes an API call to Sonilo which may "
+        "incur charges. Only use when explicitly requested by the user.\n\n"
+        "Args:\n"
+        "    video_path (str, optional): Absolute local path, or relative to "
+        "SONILO_MCP_BASE_PATH. Subject to the account upload cap. Maximum "
+        "video duration is 360 seconds (6 minutes).\n"
+        "    video_url (str, optional): HTTPS URL to a video file.\n"
+        "    prompt (str, optional): Style hint for the generated music.\n"
+        "    preserve_speech (bool, optional): Keep the source speech/vocals "
+        "in the output. Defaults to False.\n"
+        "    isolate_vocals (bool, optional): Deprecated alias for "
+        "preserve_speech; both are accepted and OR'd together. Defaults to "
+        "False.\n"
+        "    output_directory (str, optional): Where to save the result. "
+        "Defaults to SONILO_MCP_BASE_PATH.\n\n"
+        "Exactly one of video_path and video_url must be provided.\n\n"
+        "Returns:\n"
+        "    TextContent with the saved .mp4 path. On timeout the error "
+        "message includes the task_id — recover with get_sfx_task."
+    )
+)
+async def video_to_video_music(
+    video_path: str | None = None,
+    video_url: str | None = None,
+    prompt: str | None = None,
+    preserve_speech: bool = False,
+    isolate_vocals: bool = False,
+    output_directory: str | None = None,
+) -> list[TextContent]:
+    if (video_path and video_url) or (not video_path and not video_url):
+        raise Exception(
+            "Provide either video_path or video_url (exactly one, not both)"
+        )
+
+    if video_url:
+        # Same scheme guard as video_to_music/video_to_sfx: keeps file://
+        # and flag-like values away from ffprobe and the backend.
+        _require_http_url(video_url, "video")
+
+    out_path = _make_output_path(output_directory)
+    cfg = _get_config()
+
+    form: dict = {}
+    if prompt:
+        form["prompt"] = prompt
+    if preserve_speech:
+        form["preserve_speech"] = "true"
+    if isolate_vocals:
+        form["isolate_vocals"] = "true"
+
+    if video_path:
+        resolved = _resolve_input_file(
+            video_path, cfg["base_path"], _VIDEO_EXTS, "video"
+        )
+        max_mb = await _get_max_upload_size_mb()
+        size_mb = resolved.stat().st_size / (1024 * 1024)
+        if size_mb > max_mb:
+            # Cheap fail-fast: avoids a wasted ffprobe run for an
+            # obviously-oversized file. NOT the authoritative check — see
+            # _read_capped, which enforces the cap on the bytes actually read.
+            raise Exception(
+                f"Video file is too large ({size_mb:.1f} MB > {max_mb} MB cap)"
+            )
+        await _check_media_duration(str(resolved))
+        mime, _ = mimetypes.guess_type(resolved.name)
+        content = _read_capped(resolved, max_mb, "Video")
+        files = {
+            "video": (
+                resolved.name, content, mime or "application/octet-stream"
+            )
+        }
+        task_id = await _post_task_submit(
+            "/v1/video-to-video-music", data=form or None, files=files
+        )
+    else:
+        await _check_media_duration(video_url)
+        form["video_url"] = video_url
+        task_id = await _post_task_submit("/v1/video-to-video-music", data=form)
+
+    body = await _poll_task(task_id, cfg["timeout"])
+    base = _slugify(prompt) if prompt else f"v2v-music-{task_id[:8]}"
+    return await _save_task_artifacts(body, out_path, base, task_id)
+
+
+@mcp.tool(
+    description=(
+        "Generate sound effects for a video and return a NEW VIDEO with the "
+        "SFX muxed in (not just an audio file). Provide either a local "
+        "video path or a public video URL. Generation is asynchronous; this "
+        "tool waits for completion and returns the saved video path.\n\n"
+        "⚠️ COST WARNING: This tool makes an API call to Sonilo which may "
+        "incur charges. Only use when explicitly requested by the user.\n\n"
+        "Args:\n"
+        "    video_path (str, optional): Absolute local path, or relative "
+        "to SONILO_MCP_BASE_PATH. Supports .mp4/.mov/.webm/.m4v/.gif (gif "
+        "must be animated). Subject to the account's max upload size "
+        "(typically 300 MB). Maximum video duration is 180 seconds "
+        "(3 minutes).\n"
+        "    video_url (str, optional): HTTPS URL to a video file.\n"
+        "    prompt (str, optional): Overall description of the desired "
+        "sound effects (max 2000 chars).\n"
+        "    segments (list, optional): Per-segment SFX descriptions, each "
+        '{"start": float, "end": float, "prompt": str}. Backend rules: '
+        "first start must be 0; segments must be contiguous (each end == "
+        "next start); every end > start; every prompt non-empty (max 200 "
+        "chars); last end must not exceed the video duration; max 30 "
+        "segments. Invalid segments are rejected before any charge.\n"
+        "    output_directory (str, optional): Where to save the result. "
+        "Defaults to SONILO_MCP_BASE_PATH.\n\n"
+        "Exactly one of video_path and video_url must be provided.\n\n"
+        "Returns:\n"
+        "    TextContent with the saved .mp4 path. On timeout the error "
+        "message includes the task_id — recover with get_sfx_task."
+    )
+)
+async def video_to_video_sfx(
+    video_path: str | None = None,
+    video_url: str | None = None,
+    prompt: str | None = None,
+    segments: list[dict] | None = None,
+    output_directory: str | None = None,
+) -> list[TextContent]:
+    if (video_path and video_url) or (not video_path and not video_url):
+        raise Exception(
+            "Provide either video_path or video_url (exactly one, not both)"
+        )
+
+    if video_url:
+        # Same scheme guard as video_to_video_music/video_to_sfx: keeps
+        # file:// and flag-like values away from ffprobe and the backend.
+        _require_http_url(video_url, "video")
+
+    out_path = _make_output_path(output_directory)
+    cfg = _get_config()
+
+    form: dict = {}
+    if prompt and prompt.strip():
+        form["prompt"] = prompt
+    if segments is not None:
+        # Pass-through: the backend validates segments strictly and rejects
+        # bad input with a 400 before charging.
+        form["segments"] = json.dumps(segments)
+
+    if video_path:
+        resolved = _resolve_input_file(
+            video_path, cfg["base_path"], _SFX_VIDEO_EXTS, "video"
+        )
+        max_mb = await _get_max_upload_size_mb()
+        size_mb = resolved.stat().st_size / (1024 * 1024)
+        if size_mb > max_mb:
+            # Cheap fail-fast: avoids a wasted ffprobe run for an
+            # obviously-oversized file. NOT the authoritative check — see
+            # _read_capped, which enforces the cap on the bytes actually read.
+            raise Exception(
+                f"Video file is too large ({size_mb:.1f} MB > {max_mb} MB cap)"
+            )
+        await _check_media_duration(
+            str(resolved), max_seconds=_SFX_MAX_VIDEO_DURATION_SECONDS
+        )
+        mime, _ = mimetypes.guess_type(resolved.name)
+        content = _read_capped(resolved, max_mb, "Video")
+        files = {
+            "video": (
+                resolved.name, content, mime or "application/octet-stream"
+            )
+        }
+        task_id = await _post_task_submit(
+            "/v1/video-to-video-sfx", data=form or None, files=files
+        )
+    else:
+        await _check_media_duration(
+            video_url, max_seconds=_SFX_MAX_VIDEO_DURATION_SECONDS
+        )
+        form["video_url"] = video_url
+        task_id = await _post_task_submit("/v1/video-to-video-sfx", data=form)
+
+    body = await _poll_task(task_id, cfg["timeout"])
+    base = _slugify(prompt) if prompt and prompt.strip() else f"v2v-sfx-{task_id[:8]}"
+    return await _save_task_artifacts(body, out_path, base, task_id)
+
+
+@mcp.tool(
+    description=(
+        "Check a sound-effects, audio-ducking, video-to-video, or async "
+        "video-to-music (isolate_vocals) generation task and, if finished, "
+        "download its result file(s). Use this to recover a result when "
+        "text_to_sfx, video_to_sfx, audio_ducking, video_to_video_music, "
+        "video_to_video_sfx, or video_to_music(isolate_vocals=true) timed "
+        "out — their error message contains the task_id. Does not poll: a "
+        "single status check per call. This tool itself never charges.\n\n"
         "Args:\n"
         "    task_id (str): The task id returned in the timeout message.\n"
         "    output_directory (str, optional): Where to save result files. "
@@ -1730,6 +1921,7 @@ async def video_to_sfx(
         "    Still processing -> a status message; try again later. "
         "Succeeded -> the saved file path(s): audio, plus video for "
         "video_to_sfx tasks; a single .wav or .mp4 for audio_ducking "
+        "tasks; a single .mp4 for video_to_video_music/video_to_video_sfx "
         "tasks; for a video_to_music(isolate_vocals=true) task, the audio "
         "stream(s) plus the isolated vocals stem plus the mux "
         "(vocals+music mixed — the ready-to-use combined result). "

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1548,6 +1548,224 @@ async def test_video_to_music_isolate_vocals_no_audio_raises(monkeypatch, output
         )
 
 
+@respx.mock
+async def test_video_to_music_ducking_uses_async_path(monkeypatch, output_dir):
+    # ducking=False must route through the task submit+poll path (mode
+    # async), forwarding ducking as a form field, even though isolate_vocals
+    # and preserve_speech are both unset.
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    from sonilo_mcp import api
+
+    async def no_sleep(s):
+        pass
+
+    monkeypatch.setattr(api, "_poll_sleep", no_sleep)
+    submit = respx.post("https://api.test.local/v1/video-to-music").mock(
+        return_value=httpx.Response(
+            202, json={"task_id": "t-duck-1", "status": "processing"}
+        )
+    )
+    respx.get("https://api.test.local/v1/tasks/t-duck-1").mock(
+        return_value=httpx.Response(200, json={
+            "task_id": "t-duck-1", "type": "video_to_music", "status": "succeeded",
+            "audio": [{
+                "stream_index": 0, "url": "https://r2.test/a.m4a",
+                "content_type": "audio/mp4", "file_size": 1,
+            }],
+        })
+    )
+    respx.get("https://r2.test/a.m4a").mock(
+        return_value=httpx.Response(200, content=b"a")
+    )
+    await api.video_to_music(
+        video_url="https://cdn.example.com/v.mp4", ducking=False
+    )
+    from urllib.parse import parse_qs
+    sent = parse_qs(submit.calls.last.request.content.decode())
+    assert sent["mode"] == ["async"]
+    assert sent["ducking"] == ["false"]
+    assert "isolate_vocals" not in sent
+
+
+@respx.mock
+async def test_video_to_music_ducking_unset_omits_field(monkeypatch, output_dir):
+    # ducking left unset must NOT be sent at all, so the backend's default-on
+    # behavior applies — sending "ducking" here would force a value.
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    from sonilo_mcp import api
+
+    async def no_sleep(s):
+        pass
+
+    monkeypatch.setattr(api, "_poll_sleep", no_sleep)
+    submit = respx.post("https://api.test.local/v1/video-to-music").mock(
+        return_value=httpx.Response(
+            202, json={"task_id": "t-duck-2", "status": "processing"}
+        )
+    )
+    respx.get("https://api.test.local/v1/tasks/t-duck-2").mock(
+        return_value=httpx.Response(200, json={
+            "task_id": "t-duck-2", "status": "succeeded",
+            "audio": [{
+                "stream_index": 0, "url": "https://r2.test/a2.m4a",
+                "content_type": "audio/mp4", "file_size": 1,
+            }],
+        })
+    )
+    respx.get("https://r2.test/a2.m4a").mock(
+        return_value=httpx.Response(200, content=b"a")
+    )
+    await api.video_to_music(
+        video_url="https://cdn.example.com/v.mp4", preserve_speech=True
+    )
+    from urllib.parse import parse_qs
+    sent = parse_qs(submit.calls.last.request.content.decode())
+    assert "ducking" not in sent
+    assert sent["preserve_speech"] == ["true"]
+
+
+@respx.mock
+async def test_video_to_music_output_format_wav_uses_async_path(monkeypatch, output_dir):
+    # output_format="wav" alone (no isolate_vocals/preserve_speech/ducking)
+    # must also trigger the async submit+poll path.
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    from sonilo_mcp import api
+
+    async def no_sleep(s):
+        pass
+
+    monkeypatch.setattr(api, "_poll_sleep", no_sleep)
+    submit = respx.post("https://api.test.local/v1/video-to-music").mock(
+        return_value=httpx.Response(
+            202, json={"task_id": "t-wav-1", "status": "processing"}
+        )
+    )
+    respx.get("https://api.test.local/v1/tasks/t-wav-1").mock(
+        return_value=httpx.Response(200, json={
+            "task_id": "t-wav-1", "status": "succeeded",
+            "audio": [{
+                "stream_index": 0, "url": "https://r2.test/a3.wav",
+                "content_type": "audio/wav", "file_size": 1,
+            }],
+        })
+    )
+    respx.get("https://r2.test/a3.wav").mock(
+        return_value=httpx.Response(200, content=b"w")
+    )
+    await api.video_to_music(
+        video_url="https://cdn.example.com/v.mp4", output_format="wav"
+    )
+    from urllib.parse import parse_qs
+    sent = parse_qs(submit.calls.last.request.content.decode())
+    assert sent["mode"] == ["async"]
+    assert sent["output_format"] == ["wav"]
+
+
+@respx.mock
+async def test_video_to_music_ducked_stems_saved(monkeypatch, output_dir):
+    # A `ducked` list on the async result must be saved alongside audio,
+    # each labeled distinctly (Task C1's plumbing, exercised end-to-end
+    # through the tool).
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    from sonilo_mcp import api
+
+    async def no_sleep(s):
+        pass
+
+    monkeypatch.setattr(api, "_poll_sleep", no_sleep)
+    respx.post("https://api.test.local/v1/video-to-music").mock(
+        return_value=httpx.Response(
+            202, json={"task_id": "t-duck-3", "status": "processing"}
+        )
+    )
+    respx.get("https://api.test.local/v1/tasks/t-duck-3").mock(
+        return_value=httpx.Response(200, json={
+            "task_id": "t-duck-3", "type": "video_to_music", "status": "succeeded",
+            "audio": [{
+                "stream_index": 0, "url": "https://r2.test/a4.m4a",
+                "content_type": "audio/mp4", "file_size": 1,
+            }],
+            "ducked": [{
+                "stream_index": 0, "url": "https://r2.test/d4.m4a",
+                "content_type": "audio/mp4", "file_size": 1,
+            }],
+        })
+    )
+    respx.get("https://r2.test/a4.m4a").mock(return_value=httpx.Response(200, content=b"a"))
+    respx.get("https://r2.test/d4.m4a").mock(return_value=httpx.Response(200, content=b"d"))
+    result = await api.video_to_music(
+        video_url="https://cdn.example.com/v.mp4", prompt="Duck Test", ducking=True
+    )
+    assert (output_dir / "duck-test.m4a").read_bytes() == b"a"
+    assert (output_dir / "duck-test-ducked.m4a").read_bytes() == b"d"
+    texts = [t.text for t in result]
+    assert any("ducked" in t.lower() and "duck-test-ducked.m4a" in t for t in texts)
+
+
+@respx.mock
+async def test_text_to_music_output_format_wav_uses_async_path(monkeypatch, output_dir):
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    from sonilo_mcp import api
+
+    async def no_sleep(s):
+        pass
+
+    monkeypatch.setattr(api, "_poll_sleep", no_sleep)
+    submit = respx.post("https://api.test.local/v1/text-to-music").mock(
+        return_value=httpx.Response(
+            202, json={"task_id": "tm-1", "status": "processing"}
+        )
+    )
+    respx.get("https://api.test.local/v1/tasks/tm-1").mock(
+        return_value=httpx.Response(200, json={
+            "task_id": "tm-1", "type": "text_to_music", "status": "succeeded",
+            "audio": [{
+                "stream_index": 0, "url": "https://r2.test/tm.wav",
+                "content_type": "audio/wav", "file_size": 1,
+            }],
+        })
+    )
+    respx.get("https://r2.test/tm.wav").mock(
+        return_value=httpx.Response(200, content=b"w")
+    )
+    result = await api.text_to_music(prompt="lofi", duration=10, output_format="wav")
+    from urllib.parse import parse_qs
+    sent = parse_qs(submit.calls.last.request.content.decode())
+    assert sent["mode"] == ["async"]
+    assert sent["output_format"] == ["wav"]
+    assert sent["prompt"] == ["lofi"]
+    assert sent["duration"] == ["10"]
+    assert len(result) == 1
+    assert (output_dir / "lofi.wav").read_bytes() == b"w"
+
+
+@respx.mock
+async def test_text_to_music_no_output_format_still_streams(monkeypatch, output_dir):
+    # Default (no output_format) must keep streaming behavior UNCHANGED —
+    # no mode/output_format fields sent, no task_id round trip.
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    ndjson = _ndjson_bytes([
+        {"type": "audio_chunk", "stream_index": 0, "num_streams": 1,
+         "data": base64.b64encode(b"x").decode()},
+        {"type": "complete"},
+    ])
+    route = respx.post("https://api.test.local/v1/text-to-music").mock(
+        return_value=httpx.Response(200, content=ndjson)
+    )
+    from sonilo_mcp.api import text_to_music
+    await text_to_music(prompt="lofi", duration=10)
+    from urllib.parse import parse_qs
+    sent = parse_qs(route.calls.last.request.content.decode())
+    assert "mode" not in sent
+    assert "output_format" not in sent
+
+
 async def test_play_audio_rejects_nonexistent(monkeypatch):
     monkeypatch.setenv("SONILO_MCP_BASE_PATH", "/tmp")
     from sonilo_mcp.api import play_audio

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3177,6 +3177,184 @@ async def test_video_to_sfx_size_cap_enforced_on_actual_bytes(
     assert submit_route.call_count == 0
 
 
+# ---------- video-to-video ----------
+
+@respx.mock
+async def test_video_to_video_music_url_mode_submits_and_saves(monkeypatch, output_dir):
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    from sonilo_mcp import api
+    _patch_ffprobe(monkeypatch, duration=60.0)
+
+    async def no_sleep(s):
+        pass
+
+    monkeypatch.setattr(api, "_poll_sleep", no_sleep)
+    submit = respx.post("https://api.test.local/v1/video-to-video-music").mock(
+        return_value=httpx.Response(
+            202, json={"task_id": "vv-1", "status": "processing"}
+        )
+    )
+    respx.get("https://api.test.local/v1/tasks/vv-1").mock(
+        return_value=httpx.Response(200, json={
+            "task_id": "vv-1", "type": "video_to_video_music", "status": "succeeded",
+            "video": {
+                "url": "https://r2.test/o.mp4", "content_type": "video/mp4",
+                "file_size": 3,
+            },
+            "duration_seconds": 5.0,
+        })
+    )
+    respx.get("https://r2.test/o.mp4").mock(
+        return_value=httpx.Response(200, content=b"video-bytes")
+    )
+    result = await api.video_to_video_music(
+        video_url="https://example.com/clip.mp4",
+        prompt="Cinematic",
+        preserve_speech=True,
+    )
+    sent = submit.calls.last.request
+    assert b"video_url=" in sent.content
+    assert b"Cinematic" in sent.content
+    assert b"preserve_speech=true" in sent.content
+    assert len(result) == 1
+    assert (output_dir / "cinematic.mp4").read_bytes() == b"video-bytes"
+
+
+@respx.mock
+async def test_video_to_video_music_path_mode_uploads_multipart(
+    monkeypatch, output_dir, tmp_path
+):
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    from sonilo_mcp import api
+    _patch_ffprobe(monkeypatch, duration=60.0)
+
+    async def no_sleep(s):
+        pass
+
+    monkeypatch.setattr(api, "_poll_sleep", no_sleep)
+    respx.get("https://api.test.local/v1/account/services").mock(
+        return_value=httpx.Response(200, json={"max_upload_size_mb": 300})
+    )
+    video = output_dir / "clip.mp4"
+    video.write_bytes(b"FAKE-MP4")
+    submit = respx.post("https://api.test.local/v1/video-to-video-music").mock(
+        return_value=httpx.Response(
+            202, json={"task_id": "vv-2", "status": "processing"}
+        )
+    )
+    respx.get("https://api.test.local/v1/tasks/vv-2").mock(
+        return_value=httpx.Response(200, json={
+            "task_id": "vv-2", "type": "video_to_video_music", "status": "succeeded",
+            "video": {
+                "url": "https://r2.test/o2.mp4", "content_type": "video/mp4",
+                "file_size": 3,
+            },
+        })
+    )
+    respx.get("https://r2.test/o2.mp4").mock(
+        return_value=httpx.Response(200, content=b"v2")
+    )
+    api._reset_services_cache()
+    result = await api.video_to_video_music(video_path=str(video))
+    sent = submit.calls.last.request
+    assert sent.headers["content-type"].startswith("multipart/form-data")
+    assert b"FAKE-MP4" in sent.content
+    assert len(result) == 1
+    # No prompt -> base name falls back to v2v-music-{task_id[:8]}.
+    assert (output_dir / "v2v-music-vv-2.mp4").exists()
+
+
+async def test_video_to_video_music_both_inputs_rejected(monkeypatch, output_dir):
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    from sonilo_mcp.api import video_to_video_music
+    with pytest.raises(Exception, match="exactly one"):
+        await video_to_video_music(
+            video_path="/tmp/a.mp4", video_url="https://example.com/b.mp4"
+        )
+    with pytest.raises(Exception, match="exactly one"):
+        await video_to_video_music()
+
+
+@pytest.mark.parametrize("bad_url", ["file:///etc/passwd", "ftp://x/y.mp4"])
+async def test_video_to_video_music_rejects_non_http_url(monkeypatch, output_dir, bad_url):
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    from sonilo_mcp.api import video_to_video_music
+    with pytest.raises(Exception, match="http"):
+        await video_to_video_music(video_url=bad_url)
+
+
+@respx.mock
+async def test_video_to_video_sfx_url_mode_segments_passthrough(monkeypatch, output_dir):
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    from sonilo_mcp import api
+    _patch_ffprobe(monkeypatch, duration=60.0)
+
+    async def no_sleep(s):
+        pass
+
+    monkeypatch.setattr(api, "_poll_sleep", no_sleep)
+    submit = respx.post("https://api.test.local/v1/video-to-video-sfx").mock(
+        return_value=httpx.Response(
+            202, json={"task_id": "vvs-1", "status": "processing"}
+        )
+    )
+    respx.get("https://api.test.local/v1/tasks/vvs-1").mock(
+        return_value=httpx.Response(200, json={
+            "task_id": "vvs-1", "type": "video_to_video_sfx", "status": "succeeded",
+            "video": {
+                "url": "https://r2.test/sfx.mp4", "content_type": "video/mp4",
+                "file_size": 3,
+            },
+        })
+    )
+    respx.get("https://r2.test/sfx.mp4").mock(
+        return_value=httpx.Response(200, content=b"sfx-video")
+    )
+    segs = [
+        {"start": 0, "end": 2, "prompt": "whoosh"},
+        {"start": 2, "end": 5, "prompt": "boom"},
+    ]
+    result = await api.video_to_video_sfx(
+        video_url="https://example.com/clip.mp4", segments=segs
+    )
+    from urllib.parse import parse_qs
+    sent_fields = parse_qs(submit.calls.last.request.content.decode())
+    assert json.loads(sent_fields["segments"][0]) == segs
+    assert len(result) == 1
+    # No prompt -> base name falls back to v2v-sfx-{task_id[:8]}.
+    assert (output_dir / "v2v-sfx-vvs-1.mp4").read_bytes() == b"sfx-video"
+
+
+@respx.mock
+async def test_video_to_video_sfx_rejects_video_over_180s(monkeypatch, output_dir):
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    from sonilo_mcp.api import video_to_video_sfx
+    # 200s passes the music cap (360) but must fail the SFX/v2v-sfx cap (180).
+    _patch_ffprobe(monkeypatch, duration=200.0)
+    submit_route = respx.post("https://api.test.local/v1/video-to-video-sfx").mock(
+        return_value=httpx.Response(202, json={"task_id": "t-should-not-charge"})
+    )
+    with pytest.raises(Exception, match="exceeds the maximum"):
+        await video_to_video_sfx(video_url="https://example.com/long.mp4")
+    # Must NOT charge — the duration check must reject before the submit POST.
+    assert submit_route.call_count == 0
+
+
+async def test_video_to_video_sfx_both_inputs_rejected(monkeypatch, output_dir):
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    from sonilo_mcp.api import video_to_video_sfx
+    with pytest.raises(Exception, match="exactly one"):
+        await video_to_video_sfx(
+            video_path="/tmp/a.mp4", video_url="https://example.com/b.mp4"
+        )
+    with pytest.raises(Exception, match="exactly one"):
+        await video_to_video_sfx()
+
+
 @respx.mock
 async def test_get_sfx_task_processing(monkeypatch, output_dir):
     monkeypatch.setenv("SONILO_API_KEY", "k")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2299,6 +2299,83 @@ def test_normalize_task_envelope_rejects_unknown_output_type(output_type):
     assert "video" not in out
 
 
+def test_is_video_to_video_envelope():
+    from sonilo_mcp.api import _is_video_to_video_envelope
+    assert _is_video_to_video_envelope(
+        {"type": "video_to_video_music", "status": "succeeded", "video": {"url": "u"}}
+    )
+    assert _is_video_to_video_envelope(
+        {"type": "video_to_video_sfx", "status": "succeeded", "video": {"url": "u"}}
+    )
+    # Ducking's normalized envelope: video present, no audio, but its
+    # original output_url survives normalization — must not be mistaken
+    # for video-to-video.
+    assert not _is_video_to_video_envelope(
+        {"type": "audio_ducking", "status": "succeeded", "output_url": "u"}
+    )
+    # An explicit, different type is authoritative — must never be
+    # overridden by shape-sniffing, even when the shape matches (video
+    # present, no audio, no output_url).
+    assert not _is_video_to_video_envelope(
+        {"type": "video_to_sfx", "status": "succeeded", "video": {"url": "u"}}
+    )
+    # No `type` at all (defensive fallback for a malformed/older body):
+    # shape-sniffing kicks in.
+    assert _is_video_to_video_envelope({"status": "succeeded", "video": {"url": "u"}})
+    assert not _is_video_to_video_envelope(
+        {"status": "succeeded", "video": {"url": "u"}, "audio": {"url": "a"}}
+    )
+
+
+@respx.mock
+async def test_save_task_artifacts_saves_video_only(monkeypatch, tmp_path):
+    # A video-to-video result (`{"video": {...}}`, no `audio`) must be saved
+    # like the ducking video-only case — no "no audio artifact" error.
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    respx.get("https://r2.test/v2v.mp4").mock(
+        return_value=httpx.Response(200, content=b"v2v-bytes")
+    )
+    from sonilo_mcp.api import _save_task_artifacts
+    body = {
+        "task_id": "v1", "type": "video_to_video_music", "status": "succeeded",
+        "video": {"url": "https://r2.test/v2v.mp4", "content_type": "video/mp4", "file_size": 9},
+    }
+    result = await _save_task_artifacts(body, tmp_path, "v2v-scene", "v1")
+    assert len(result) == 1
+    expected = tmp_path / "v2v-scene.mp4"
+    assert expected.read_bytes() == b"v2v-bytes"
+    assert str(expected) in result[0].text
+
+
+@respx.mock
+async def test_save_music_task_artifacts_saves_ducked_stems(monkeypatch, tmp_path):
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    respx.get("https://r2.test/a.m4a").mock(return_value=httpx.Response(200, content=b"a"))
+    respx.get("https://r2.test/d0.m4a").mock(return_value=httpx.Response(200, content=b"d0"))
+    respx.get("https://r2.test/d1.m4a").mock(return_value=httpx.Response(200, content=b"d1"))
+    from sonilo_mcp.api import _save_music_task_artifacts
+    body = {
+        "task_id": "m-duck-1", "type": "video_to_music", "status": "succeeded",
+        "audio": [
+            {"stream_index": 0, "url": "https://r2.test/a.m4a",
+             "content_type": "audio/mp4", "file_size": 1},
+        ],
+        "ducked": [
+            {"stream_index": 0, "url": "https://r2.test/d0.m4a",
+             "content_type": "audio/mp4", "file_size": 2},
+            {"stream_index": 1, "url": "https://r2.test/d1.m4a",
+             "content_type": "audio/mp4", "file_size": 2},
+        ],
+    }
+    result = await _save_music_task_artifacts(body, tmp_path, "score", "m-duck-1")
+    assert (tmp_path / "score-ducked-0.m4a").read_bytes() == b"d0"
+    assert (tmp_path / "score-ducked-1.m4a").read_bytes() == b"d1"
+    texts = [t.text for t in result]
+    ducked_texts = [t for t in texts if "score-ducked-0.m4a" in t or "score-ducked-1.m4a" in t]
+    assert len(ducked_texts) == 2
+    assert all("ducked" in t.lower() for t in ducked_texts)
+
+
 @respx.mock
 async def test_save_task_artifacts_unknown_output_type_raises_recoverable(
     monkeypatch, tmp_path
@@ -2386,18 +2463,23 @@ async def test_save_task_artifacts_no_artifacts_still_raises(monkeypatch, tmp_pa
 async def test_save_task_artifacts_sfx_video_without_audio_still_raises(
     monkeypatch, tmp_path
 ):
-    # An SFX-shaped body is NOT a ducking envelope: it must always carry an
-    # audio artifact. A video-only SFX body means the audio half of a paid
-    # result went missing — downloading just the mp4 and reporting success
-    # would silently lose it, so this still raises the charged-and-
-    # recoverable error. (The video-only exemption belongs to ducking alone.)
+    # An SFX-shaped body is NOT a ducking or video-to-video envelope: it must
+    # always carry an audio artifact. A video-only SFX body means the audio
+    # half of a paid result went missing — downloading just the mp4 and
+    # reporting success would silently lose it, so this still raises the
+    # charged-and-recoverable error. (The video-only exemption belongs to
+    # ducking and video-to-video alone.) `type` is set to a real, unrelated
+    # task type — the backend's /v1/tasks/{id} always includes `type` — so
+    # this pins that an explicit non-v2v type is never overridden by the
+    # video-to-video shape-sniffing fallback (which only applies when `type`
+    # is missing entirely).
     monkeypatch.setenv("SONILO_API_KEY", "k")
     route = respx.get("https://r2.test/orphan.mp4").mock(
         return_value=httpx.Response(200, content=b"mp4-bytes")
     )
     from sonilo_mcp.api import _save_task_artifacts
     body = {
-        "task_id": "t-orphan", "status": "succeeded",
+        "task_id": "t-orphan", "type": "video_to_sfx", "status": "succeeded",
         "video": {"url": "https://r2.test/orphan.mp4", "content_type": "video/mp4"},
     }
     with pytest.raises(Exception) as exc:


### PR DESCRIPTION
## Summary

Brings the MCP server to parity with the current public API.

> **Note:** this branch was built on top of the unmerged `feat/isolate-vocals` branch, so this PR also carries those 3 `isolate_vocals` commits (vocal-stem + mux + timeout recovery). It ships the isolate_vocals work and the new endpoints together, targeting `main`.

New in this PR (on top of isolate_vocals):

- Add `video_to_video_music` and `video_to_video_sfx` MCP tools (async, **video output**) — submit → poll → save the `.mp4`.
- Exempt video-only video-to-video results from the "audio required" save guard (new `_is_video_to_video_envelope` helper), and download `ducked` stems in the async music save path.
- Extend the `video_to_music` tool: add `preserve_speech`, `output_format`, and `ducking` (async path triggers on any of them; `ducking` sent only when set).
- Extend the `text_to_music` tool: add `output_format` (routes to the async path for `wav`).
- `get_sfx_task` recovery now covers video-to-video tasks.
- Version `0.5.0` → `0.6.0`. Not published.

## Testing

- `python -m pytest tests/`: **240/240 pass**; `list_tools()` shows both new tools.
- **Production E2E:** `video_to_video_music` saved a valid mp4; `text_to_music(output_format="wav")` produced real `pcm_s16le` wav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013rzBraznKwUMK2JQwTwf5r
