### PR TITLE
docs: attribute dashboard links with UTM parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For sound design, **`video_to_sfx`** watches your video and generates matching s
 claude mcp add sonilo --env SONILO_API_KEY=sks_... -- uvx sonilo-mcp
 ```
 
-Get your API key from the [Sonilo dashboard](https://platform.sonilo.com/dashboard/api-keys), then start a session and ask, e.g. *"Make background music that matches this video: `~/Desktop/promo.mp4`."*
+Get your API key from the [Sonilo dashboard](https://platform.sonilo.com/dashboard/api-keys?utm_source=sonilo_mcp&utm_medium=readme&utm_campaign=mcp_quickstart), then start a session and ask, e.g. *"Make background music that matches this video: `~/Desktop/promo.mp4`."*
 
 ## Why Sonilo
 
@@ -39,7 +39,7 @@ The `play_audio` tool requires PortAudio at runtime (for `sounddevice`). On macO
 
 ## Quickstart with Claude Desktop
 
-1. **Get your API key** from the [Sonilo dashboard](https://platform.sonilo.com/dashboard/api-keys).
+1. **Get your API key** from the [Sonilo dashboard](https://platform.sonilo.com/dashboard/api-keys?utm_source=sonilo_mcp&utm_medium=readme&utm_campaign=mcp_quickstart).
 
 2. **Install the `uv` package manager** (provides `uvx`):
 
@@ -71,7 +71,7 @@ The `play_audio` tool requires PortAudio at runtime (for `sounddevice`). On macO
 
 ## Quickstart with Codex
 
-1. **Get your API key** from the [Sonilo dashboard](https://platform.sonilo.com/dashboard/api-keys).
+1. **Get your API key** from the [Sonilo dashboard](https://platform.sonilo.com/dashboard/api-keys?utm_source=sonilo_mcp&utm_medium=readme&utm_campaign=mcp_quickstart).
 
 2. **Install the `uv` package manager** (provides `uvx`):
 


### PR DESCRIPTION
The Sonilo dashboard now captures first-touch UTM parameters and can break new API keys down by acquisition channel (sonilo-ai/sonilo-api-dashboard#171). That instrumentation is only a receiver — it can attribute a visitor only if the link they followed carries the parameters. Until this lands, everyone who arrives from this package is recorded as `direct`.

Tags the three "get your API key" links with `utm_source=sonilo_mcp&utm_medium=readme&utm_campaign=mcp_quickstart`.

Deliberately **not** tagged:
- The troubleshooting row (`Invalid SONILO_API_KEY`) and the two billing links — those are support paths for people who already have a key, and tagging them would mix support clicks into acquisition data.
- `server.json` and `src/sonilo_mcp/api.py` — no code changes here at all. `server.json` has no dashboard link to tag, and the URLs in `api.py` are the same support paths, with tests asserting on them.

Note that GitHub and PyPI render this same README, so they share one `utm_source`. They are not separately distinguishable, which is fine — the useful question is which package brought the user, not which host they read about it on.

Docs only. No code, no dependency, no release required.