### PR TITLE
fix: pin the mcp SDK below 2.0 and make CI honour the lockfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,16 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
+      # uv sync, not pip install: the lockfile is what pins mcp to a 1.x that
+      # still ships mcp.server.fastmcp. A plain resolve picks up whatever is
+      # newest on PyPI, so mcp 2.x turned every test in this suite into an
+      # import error the moment it was published.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
       - name: Install
-        run: pip install -e ".[dev]"
+        run: uv sync --extra dev --frozen
       - name: Run tests
-        run: pytest -v
+        run: uv run pytest -v
 
   build-and-publish:
     needs: test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,10 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "mcp[cli]>=1.6.0",
+    # Capped below 2.0: mcp 2.x removed mcp.server.fastmcp, which every tool
+    # in this package imports. Without the cap a fresh install silently
+    # resolves to 2.x and fails at import rather than at resolution.
+    "mcp[cli]>=1.6.0,<2",
     "httpx>=0.27",
     "sounddevice>=0.5.1",
     "soundfile>=0.13.1",


### PR DESCRIPTION
## Problem

The upstream **mcp** Python SDK (Anthropic's, not this package) published **2.0.0**, which removed `mcp.server.fastmcp` — the module every tool here imports. The `v0.10.0` release run failed with all 290 tests erroring at import:

```
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

Nothing was published; PyPI is still on 0.9.0.

## Why it got through

Two independent gaps, either of which alone would have prevented this:

1. `pyproject.toml` declared `"mcp[cli]>=1.6.0"` with **no upper bound**, so a fresh resolve takes whatever is newest on PyPI.
2. `release.yml` installed with `pip install -e ".[dev]"`, which **ignores `uv.lock`**. The lockfile already pinned `mcp==1.28.0` — nothing ever read it.

Worth noting: this repo's workflows only run on tag pushes and `workflow_dispatch`, not on pull requests, so the breakage was invisible until release time.

## Fix

- Cap the dependency at `>=1.6.0,<2` so anyone installing the package gets a version that actually imports.
- Switch CI to `uv sync --extra dev --frozen` + `uv run pytest`, so the lockfile determines the tested environment and a drifted lock fails loudly instead of silently resolving something else.

## Verification

Ran the exact command CI will run:

```
uv sync --extra dev --frozen   -> mcp 1.28.0
uv run python -c "import mcp.server.fastmcp"  -> OK
uv run pytest -q               -> 290 passed
```
