### PR TITLE
feat: add optional ducking param to the dubbing tool (0.11.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sonilo-mcp"
-version = "0.10.0"
+version = "0.11.0"
 description = "MCP server for Sonilo AI music generation API"
 authors = [{ name = "Sonilo", email = "support@sonilo.com" }]
 readme = "README.md"

--- a/src/sonilo_mcp/api.py
+++ b/src/sonilo_mcp/api.py
@@ -2684,6 +2684,10 @@ async def video_to_video_sound(
         "    languages (list, optional): Target language codes, e.g. "
         '["es", "fr"]. Supported: en, zh_cn, ja, ko, pt, es, de, fr, it, '
         'ru. Omit to get the default ["zh_cn", "es", "fr"].\n'
+        "    ducking (bool, optional): Duck the background music/effects "
+        "bed under the dubbed voice while it speaks. Off by default: the "
+        "bed is always kept, at a constant level unless this is true. "
+        "Free.\n"
         "    output_directory (str, optional): Where to save the results. "
         "Defaults to SONILO_MCP_BASE_PATH.\n\n"
         "Exactly one of video_path and video_url must be provided.\n\n"
@@ -2698,6 +2702,7 @@ async def dubbing(
     video_path: str | None = None,
     video_url: str | None = None,
     languages: list[str] | None = None,
+    ducking: bool | None = None,
     output_directory: str | None = None,
 ) -> list[TextContent]:
     if (video_path and video_url) or (not video_path and not video_url):
@@ -2728,6 +2733,10 @@ async def dubbing(
         # list and rejects an unknown code with a 422 before charging, and a
         # hardcoded copy would make this server reject codes added later.
         form["languages"] = json.dumps(languages)
+    # Default-OFF server-side (the opposite of video_to_music's ducking):
+    # omitted when unset so the server default applies.
+    if ducking is not None:
+        form["ducking"] = "true" if ducking else "false"
 
     files, extra_form = await _stage_video_input(
         video_path, video_url, cfg["base_path"], _DUBBING_MAX_VIDEO_DURATION_SECONDS

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5220,6 +5220,36 @@ async def test_dubbing_omits_languages_when_unset(monkeypatch, output_dir):
     )
     await api.dubbing(video_url="https://example.com/clip.mp4")
     assert b"languages" not in submit.calls.last.request.content
+    # ducking unset → omitted so the server default (off) applies.
+    assert b"ducking" not in submit.calls.last.request.content
+
+
+@respx.mock
+async def test_dubbing_sends_ducking_when_set(monkeypatch, output_dir):
+    monkeypatch.setenv("SONILO_API_KEY", "k")
+    monkeypatch.setenv("SONILO_API_URL", "https://api.test.local")
+    from sonilo_mcp import api
+    _patch_ffprobe(monkeypatch, duration=60.0)
+
+    async def no_sleep(s):
+        pass
+
+    monkeypatch.setattr(api, "_poll_sleep", no_sleep)
+    submit = respx.post("https://api.test.local/v1/dubbing").mock(
+        return_value=httpx.Response(202, json={"task_id": "db-3", "status": "processing"})
+    )
+    respx.get("https://api.test.local/v1/tasks/db-3").mock(
+        return_value=httpx.Response(200, json={
+            "task_id": "db-3", "type": "dubbing", "status": "succeeded",
+            "outputs": {"es": "https://r2.test/es.mp4"},
+        })
+    )
+    respx.get("https://r2.test/es.mp4").mock(
+        return_value=httpx.Response(200, content=b"es-bytes")
+    )
+    await api.dubbing(video_url="https://example.com/clip.mp4", ducking=True)
+    assert b'name="ducking"\r\n\r\ntrue' in submit.calls.last.request.content or \
+        b"ducking=true" in submit.calls.last.request.content
 
 
 async def test_dubbing_rejects_both_inputs(monkeypatch, output_dir):


### PR DESCRIPTION
Propagates the dashboard's new dubbing `ducking` parameter (sonilo-api-dashboard#188, live in prod):

- `dubbing` tool gains `ducking: bool | None` — sent as the `ducking` form field only when set; omitted → server default (off).
- Semantics: off (default) keeps the background music/effects bed at a constant level; `true` ducks the bed under the dubbed voice while it speaks. Free; polarity is the opposite of `video_to_music`'s default-on ducking.
- Tool docstring documents the arg; tests cover sent-when-true and omitted-when-unset. 291 passed.
- Version bumped to 0.11.0.

Release reminder: the MCP-Registry publish job races PyPI on every tag — rerun the failed registry run after PyPI lands, never re-tag.