### PR TITLE
Follow the API's shorter 429 wording (tests)

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -428,12 +428,11 @@ def test_raise_http_error_429():
     "message",
     [
         "Rate limit exceeded: your account allows 60 requests per minute. "
-        "Rejected requests count toward the limit too, so wait for the next "
-        "minute window (up to 60 sec) rather than retrying right away. "
-        "To raise your limit, contact info@sonilo.com.",
-        "Too many concurrent generations: 5 of 5 in progress. Wait for one to "
-        "finish before starting another. To raise your limit, contact "
+        "Please retry after 1 minute. To raise your limit, please contact "
         "info@sonilo.com.",
+        "Too many concurrent generations: 5 of 5 in progress. Please wait for "
+        "one to finish before starting another. To raise your limit, please "
+        "contact info@sonilo.com.",
     ],
 )
 def test_raise_http_error_429_does_not_repeat_the_backend_phrase(message):


### PR DESCRIPTION
## Why

The backend's two rate-limit sentences got shorter and both now ask politely (sonilo-api-dashboard#226):

```
Rate limit exceeded: your account allows 60 requests per minute. Please retry
after 1 minute. To raise your limit, please contact info@sonilo.com.

Too many concurrent generations: 5 of 5 in progress. Please wait for one to
finish before starting another. To raise your limit, please contact
info@sonilo.com.
```

These tests quote them verbatim on purpose — they pin that the prefix is not repeated and that the text arrives whole — so they move with the source.

## Scope

Test-only. `_announces_rate_limit` keys on the openings (`rate limit exceeded`, `too many concurrent generations`), which are unchanged, so no behaviour differs and no release is needed. The README rows quote only those openings, so they stand as-is.

`pytest` — **303 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
