### PR TITLE
feat: authenticate from the sonilo login credential (0.16.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,20 @@ For sound design, **`video_to_sfx`** watches your video and generates matching s
 
 ## Quickstart with Claude Code
 
+Sign in once with the CLI, then add the server with no secret in the config:
+
 ```bash
-claude mcp add sonilo --env SONILO_API_KEY=sks_... -- uvx sonilo-mcp
+npm install -g sonilo-cli && sonilo login
+claude mcp add sonilo -- uvx sonilo-mcp
 ```
 
-Get your API key from the [Sonilo dashboard](https://platform.sonilo.com/dashboard/api-keys?utm_source=sonilo_mcp&utm_medium=readme&utm_campaign=mcp_quickstart), then start a session and ask, e.g. *"Make background music that matches this video: `~/Desktop/promo.mp4`."*
+Or hold an API key yourself — get one from the [Sonilo dashboard](https://platform.sonilo.com/dashboard/api-keys?utm_source=sonilo_mcp&utm_medium=readme&utm_campaign=mcp_quickstart):
+
+```bash
+claude mcp add sonilo --env SONILO_API_KEY=sk-... -- uvx sonilo-mcp
+```
+
+Then start a session and ask, e.g. *"Make background music that matches this video: `~/Desktop/promo.mp4`."*
 
 ## Why Sonilo
 
@@ -40,7 +49,10 @@ The `play_audio` tool requires PortAudio at runtime (for `sounddevice`). On macO
 
 ## Quickstart with Claude Desktop
 
-1. **Get your API key** from the [Sonilo dashboard](https://platform.sonilo.com/dashboard/api-keys?utm_source=sonilo_mcp&utm_medium=readme&utm_campaign=mcp_quickstart).
+1. **Authenticate**, either way round:
+
+   - Sign in with the CLI — `npm install -g sonilo-cli && sonilo login` — and leave `"env": {}` below. Nothing secret goes in the config file.
+   - Or **get an API key** from the [Sonilo dashboard](https://platform.sonilo.com/dashboard/api-keys?utm_source=sonilo_mcp&utm_medium=readme&utm_campaign=mcp_quickstart) and put it in `"env"`.
 
 2. **Install the `uv` package manager** (provides `uvx`):
 
@@ -58,13 +70,20 @@ The `play_audio` tool requires PortAudio at runtime (for `sounddevice`). On macO
        "sonilo": {
          "command": "uvx",
          "args": ["sonilo-mcp"],
-         "env": {
-           "SONILO_API_KEY": "sks_...",
-           "SONILO_API_URL": "https://api.sonilo.com",
-           "TIME_OUT_SECONDS": "600"
-         }
+         "env": {}
        }
      }
+   }
+   ```
+
+   That is the whole config when you have signed in with `sonilo login`. To
+   hold a key instead, or to change the defaults:
+
+   ```json
+   "env": {
+     "SONILO_API_KEY": "sk-...",
+     "SONILO_API_URL": "https://api.sonilo.com",
+     "TIME_OUT_SECONDS": "600"
    }
    ```
 
@@ -72,7 +91,22 @@ The `play_audio` tool requires PortAudio at runtime (for `sounddevice`). On macO
 
 ## Quickstart with Codex
 
-1. **Get your API key** from the [Sonilo dashboard](https://platform.sonilo.com/dashboard/api-keys?utm_source=sonilo_mcp&utm_medium=readme&utm_campaign=mcp_quickstart).
+Signed in with the CLI (`npm install -g sonilo-cli && sonilo login`), the whole
+setup is one command:
+
+```bash
+codex mcp add sonilo -- uvx sonilo-mcp
+```
+
+Or, holding a key yourself:
+
+```bash
+codex mcp add sonilo --env SONILO_API_KEY=sk-... -- uvx sonilo-mcp
+```
+
+To configure it by hand instead:
+
+1. **Get your API key** from the [Sonilo dashboard](https://platform.sonilo.com/dashboard/api-keys?utm_source=sonilo_mcp&utm_medium=readme&utm_campaign=mcp_quickstart) — or skip this step if you signed in with `sonilo login`.
 
 2. **Install the `uv` package manager** (provides `uvx`):
 
@@ -92,8 +126,9 @@ The `play_audio` tool requires PortAudio at runtime (for `sounddevice`). On macO
    command = "uvx"
    args = ["sonilo-mcp"]
 
+   # Omit this whole block when you have signed in with `sonilo login`.
    [mcp_servers.sonilo.env]
-   SONILO_API_KEY = "sk_..."
+   SONILO_API_KEY = "sk-..."
    SONILO_API_URL = "https://api.sonilo.com"
    TIME_OUT_SECONDS = "600"
    ```
@@ -117,11 +152,24 @@ The assistant will call the matching tool (`text_to_music`, `video_to_music`, `t
 
 ## Configuration
 
+### Authentication
+
+The server takes its key from `SONILO_API_KEY` if that is set, and otherwise
+from the credential written by `sonilo login`
+(`~/.config/sonilo/credentials.json`, or `$XDG_CONFIG_HOME/sonilo/`). The
+environment variable wins on purpose, so any config that already sets it keeps
+resolving to the same account after an upgrade.
+
+The credential is looked up by the server's own `SONILO_API_URL`, so a staging
+server never picks up a production sign-in. This server only ever **reads** the
+file: run `sonilo login` again to renew it (keys from a sign-in expire after 90
+days) and `sonilo logout` to revoke it.
+
 ### Environment Variables
 
 | Variable | Default | Description |
 |---|---|---|
-| `SONILO_API_KEY` | _(required)_ | Bearer token. |
+| `SONILO_API_KEY` | _(from `sonilo login`)_ | Bearer token. Required only if you have not signed in with the CLI. |
 | `SONILO_API_URL` | `https://api.sonilo.com` | Public API base URL. |
 | `SONILO_MCP_BASE_PATH` | `~/Desktop` | Default output directory and base for relative input paths. Also the confinement boundary (see below). |
 | `SONILO_MCP_ALLOW_ANY_PATH` | `false` | Set to `true` to let tools read/write files outside `SONILO_MCP_BASE_PATH`. |
@@ -189,7 +237,8 @@ File names come from the prompt (slugified, truncated to 80 characters). When th
 
 | Message | What to do |
 |---|---|
-| `Invalid SONILO_API_KEY` | Verify the key at <https://platform.sonilo.com/dashboard/api-keys>. |
+| `SONILO_API_KEY not set and no stored credential found` | Run `sonilo login`, or set `SONILO_API_KEY` in the server's config. |
+| `Invalid SONILO_API_KEY` | Verify the key at <https://platform.sonilo.com/dashboard/api-keys>. If you signed in with the CLI, the key may have expired (90 days) or been revoked — run `sonilo login` again. |
 | `Insufficient minutes` / `Credit limit exceeded` | Top up at <https://platform.sonilo.com/dashboard/billing>. |
 | `You've used your N free trial calls for <service>` | That service's free trial is spent. Add a payment method at <https://platform.sonilo.com/dashboard/billing> — retrying can't help. `get_account_services` shows what is left on the other services. |
 | `Rate limit exceeded: your account allows N requests per minute` | Calls are going out too fast. The counter runs on a fixed 60-second window and rejected calls count toward it too, so wait the window out instead of retrying inside it. `get_account_services` reports your `rpm_limit`; email <info@sonilo.com> to raise it. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sonilo-mcp"
-version = "0.15.0"
+version = "0.16.0"
 description = "MCP server for Sonilo AI music generation API"
 authors = [{ name = "Sonilo", email = "support@sonilo.com" }]
 readme = "README.md"

--- a/src/sonilo_mcp/api.py
+++ b/src/sonilo_mcp/api.py
@@ -22,6 +22,8 @@ import httpx
 from mcp.server.fastmcp import FastMCP
 from mcp.types import TextContent
 
+from .credentials import read_api_key
+
 mcp = FastMCP("Sonilo")
 
 try:
@@ -72,9 +74,16 @@ def _get_config() -> dict:
     The cost is one os.getenv per tool call — negligible.
     """
     base_default = str(Path.home() / "Desktop")
+    api_url = os.getenv("SONILO_API_URL", "https://api.sonilo.com")
+    # Env var first: any host config that already sets SONILO_API_KEY must keep
+    # resolving to the same account after an upgrade. The credential file
+    # written by `sonilo login` is the fallback that lets a config carry no
+    # secret at all. Keyed by api_url so a staging server never picks up a
+    # production credential.
+    api_key = os.getenv("SONILO_API_KEY") or read_api_key(api_url.rstrip("/"))
     return {
-        "api_key": os.getenv("SONILO_API_KEY"),
-        "api_url": os.getenv("SONILO_API_URL", "https://api.sonilo.com"),
+        "api_key": api_key,
+        "api_url": api_url,
         "base_path": os.getenv("SONILO_MCP_BASE_PATH", base_default),
         # Default aligns with the backend's generation read timeout (600s): a
         # long generation can keep running—and charging—on the backend up to
@@ -434,6 +443,21 @@ _BILLING_URL = "https://platform.sonilo.com/dashboard/billing"
 _API_KEYS_URL = "https://platform.sonilo.com/dashboard/api-keys"
 
 
+def _require_api_key(cfg: dict) -> str:
+    """The key from cfg, or an error naming both ways to provide one.
+
+    Shared by all three request helpers so a user who is signed out gets the
+    same remediation whichever tool they happened to call.
+    """
+    api_key = cfg["api_key"]
+    if not api_key:
+        raise Exception(
+            "SONILO_API_KEY not set and no stored credential found — run "
+            f"`sonilo login`, or create a key at {_API_KEYS_URL}"
+        )
+    return api_key
+
+
 class SoniloHTTPError(Exception):
     """A backend HTTP error, carrying the status code.
 
@@ -561,10 +585,9 @@ async def _http_get_json(path: str, params: dict | None = None) -> dict:
     endpoints (would risk double-charging on transient 5xx).
     """
     cfg = _get_config()
-    if not cfg["api_key"]:
-        raise Exception(f"SONILO_API_KEY not set — see {_API_KEYS_URL}")
+    api_key = _require_api_key(cfg)
     url = cfg["api_url"].rstrip("/") + path
-    headers = {"Authorization": f"Bearer {cfg['api_key']}", **_CLIENT_HEADERS, **_host_headers()}
+    headers = {"Authorization": f"Bearer {api_key}", **_CLIENT_HEADERS, **_host_headers()}
 
     for attempt in (1, 2):
         try:
@@ -669,10 +692,9 @@ async def _post_streaming_generation(
     No retry — generation endpoints are non-idempotent and could double-charge.
     """
     cfg = _get_config()
-    if not cfg["api_key"]:
-        raise Exception(f"SONILO_API_KEY not set — see {_API_KEYS_URL}")
+    api_key = _require_api_key(cfg)
     url = cfg["api_url"].rstrip("/") + path
-    headers = {"Authorization": f"Bearer {cfg['api_key']}", **_CLIENT_HEADERS, **_host_headers()}
+    headers = {"Authorization": f"Bearer {api_key}", **_CLIENT_HEADERS, **_host_headers()}
 
     try:
         async with httpx.AsyncClient(timeout=cfg["timeout"]) as client:
@@ -727,10 +749,9 @@ async def _post_task_submit(
     _post_streaming_generation. Uses cfg["timeout"] (video uploads are slow).
     """
     cfg = _get_config()
-    if not cfg["api_key"]:
-        raise Exception(f"SONILO_API_KEY not set — see {_API_KEYS_URL}")
+    api_key = _require_api_key(cfg)
     url = cfg["api_url"].rstrip("/") + path
-    headers = {"Authorization": f"Bearer {cfg['api_key']}", **_CLIENT_HEADERS, **_host_headers()}
+    headers = {"Authorization": f"Bearer {api_key}", **_CLIENT_HEADERS, **_host_headers()}
     try:
         async with httpx.AsyncClient(timeout=cfg["timeout"]) as client:
             r = await client.post(url, headers=headers, data=data, files=files)

--- a/src/sonilo_mcp/credentials.py
+++ b/src/sonilo_mcp/credentials.py
@@ -1,0 +1,79 @@
+"""Read-only access to the credential file written by `sonilo login`.
+
+Format and location are a cross-repo contract shared with the CLIs
+(`sonilo-js/packages/cli/src/credentials.ts`, and the Python CLI once it lands).
+This server only ever reads: it never creates, rewrites or repairs the file.
+
+The path is fixed in code and cannot be influenced by any tool argument, which
+is why it is read directly instead of through `api._is_within_base` — that
+confinement exists to stop *caller-supplied* paths escaping
+SONILO_MCP_BASE_PATH, and a credential living outside that base is deliberate.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+FORMAT_VERSION = 1
+
+# (path, mtime_ns, size) -> parsed credentials mapping. `_get_config()` runs on
+# every tool call, so an uncached reader would open this file constantly.
+_cache: Dict[Tuple[str, int, int], Dict[str, Any]] = {}
+
+
+def credentials_path() -> Path:
+    """Where the CLIs store credentials: $XDG_CONFIG_HOME/sonilo, else ~/.config/sonilo."""
+    base = os.environ.get("XDG_CONFIG_HOME")
+    root = Path(base) if base else Path(os.environ.get("HOME", str(Path.home()))) / ".config"
+    return root / "sonilo" / "credentials.json"
+
+
+def clear_cache() -> None:
+    """Drop the cache. Used by tests; not needed at runtime."""
+    _cache.clear()
+
+
+def _load() -> Dict[str, Any]:
+    path = credentials_path()
+    try:
+        st = path.stat()
+    except OSError:
+        return {}
+    key = (str(path), st.st_mtime_ns, st.st_size)
+    cached = _cache.get(key)
+    if cached is not None:
+        return cached
+
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        # Unreadable or malformed reads as "no credential" — the server still
+        # works for anyone using SONILO_API_KEY, and `sonilo login` will
+        # rewrite the file.
+        parsed = {}
+
+    creds: Dict[str, Any] = {}
+    if isinstance(parsed, dict):
+        version = parsed.get("version")
+        # A newer format may mean fields we would misread. Ignoring the file is
+        # safer than guessing at a credential.
+        if not (isinstance(version, int) and version > FORMAT_VERSION):
+            found = parsed.get("credentials")
+            if isinstance(found, dict):
+                creds = found
+
+    _cache.clear()  # only ever one file; keep the cache single-entry
+    _cache[key] = creds
+    return creds
+
+
+def read_api_key(api_base: str) -> Optional[str]:
+    """The stored key for `api_base`, or None. Never raises."""
+    entry = _load().get(api_base)
+    if isinstance(entry, dict):
+        key = entry.get("api_key")
+        if isinstance(key, str) and key:
+            return key
+    return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def reset_env(monkeypatch):
+def reset_env(monkeypatch, tmp_path):
     """Clear Sonilo env vars before each test so tests must set what they need."""
     for key in (
         "SONILO_API_KEY",
@@ -14,6 +14,15 @@ def reset_env(monkeypatch):
         "TIME_OUT_SECONDS",
     ):
         monkeypatch.delenv(key, raising=False)
+
+    # The credential reader looks under $XDG_CONFIG_HOME / $HOME. Without this,
+    # the suite would read the developer's real ~/.config/sonilo/credentials.json,
+    # so results would depend on whether they happen to be signed in.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    from sonilo_mcp import credentials
+
+    credentials.clear_cache()
 
 
 @pytest.fixture

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5764,3 +5764,125 @@ def test_video_to_video_sound_never_exposes_output_format():
     assert (
         "output_format" not in inspect.signature(api.video_to_video_sound).parameters
     )
+
+
+# ---------- Authenticating from the `sonilo login` credential ----------
+
+def _write_credentials(path, *, api_key: str, api_base: str = "https://api.sonilo.com"):
+    """Write the shared credential file the CLIs produce (see credentials.py)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "credentials": {
+                    api_base: {
+                        "api_key": api_key,
+                        "key_id": "key-1",
+                        "account_id": "acct-1",
+                        "account_name": "Acme",
+                        "expires_at": "2026-11-09T04:12:00Z",
+                        "created_at": "2026-08-11T04:12:00Z",
+                        "created_by": "sonilo-cli/0.12.0",
+                    }
+                },
+            }
+        )
+    )
+
+
+def test_get_config_prefers_the_env_var_over_the_stored_credential(tmp_path, monkeypatch):
+    """The compatibility guarantee: an existing host config keeps working."""
+    monkeypatch.setenv("SONILO_API_KEY", "sk-from-env")
+    from sonilo_mcp.credentials import credentials_path
+    _write_credentials(credentials_path(), api_key="sk-from-file")
+
+    from sonilo_mcp.api import _get_config
+    assert _get_config()["api_key"] == "sk-from-env"
+
+
+def test_get_config_falls_back_to_the_stored_credential(tmp_path):
+    from sonilo_mcp.credentials import credentials_path
+    _write_credentials(credentials_path(), api_key="sk-from-file")
+
+    from sonilo_mcp.api import _get_config
+    assert _get_config()["api_key"] == "sk-from-file"
+
+
+def test_get_config_matches_the_credential_to_the_configured_api_url(tmp_path, monkeypatch):
+    monkeypatch.setenv("SONILO_API_URL", "https://api.staging.sonilo.com")
+    from sonilo_mcp.credentials import credentials_path
+    _write_credentials(credentials_path(), api_key="sk-prod")  # written for prod
+
+    from sonilo_mcp.api import _get_config
+    assert _get_config()["api_key"] is None
+
+
+def test_get_config_tolerates_a_trailing_slash_on_the_api_url(tmp_path, monkeypatch):
+    """The CLIs strip trailing slashes before keying the store, so the server
+    must too or a `SONILO_API_URL=…/` config would never find its credential."""
+    monkeypatch.setenv("SONILO_API_URL", "https://api.sonilo.com/")
+    from sonilo_mcp.credentials import credentials_path
+    _write_credentials(credentials_path(), api_key="sk-from-file")
+
+    from sonilo_mcp.api import _get_config
+    assert _get_config()["api_key"] == "sk-from-file"
+
+
+@respx.mock
+async def test_requests_use_the_stored_credential(tmp_path):
+    from sonilo_mcp.credentials import credentials_path
+    _write_credentials(credentials_path(), api_key="sk-from-file")
+
+    route = respx.get("https://api.sonilo.com/v1/account/usage").mock(
+        return_value=httpx.Response(200, json={"ok": True})
+    )
+    from sonilo_mcp.api import _http_get_json
+    await _http_get_json("/v1/account/usage")
+    assert route.calls.last.request.headers["authorization"] == "Bearer sk-from-file"
+
+
+@respx.mock
+async def test_missing_key_message_mentions_both_ways_in(tmp_path):
+    from sonilo_mcp.api import _http_get_json
+    with pytest.raises(Exception, match="SONILO_API_KEY"):
+        await _http_get_json("/v1/account/usage")
+    with pytest.raises(Exception, match="sonilo login"):
+        await _http_get_json("/v1/account/usage")
+
+
+@respx.mock
+async def test_task_submit_uses_the_stored_credential(tmp_path):
+    """The gate is duplicated across three helpers; a missed one would leave
+    one tool family unable to use a sign-in."""
+    from sonilo_mcp.credentials import credentials_path
+    _write_credentials(credentials_path(), api_key="sk-from-file")
+
+    route = respx.post("https://api.sonilo.com/v1/text-to-sfx").mock(
+        return_value=httpx.Response(202, json={"task_id": "t1"})
+    )
+    from sonilo_mcp.api import _post_task_submit
+    assert await _post_task_submit("/v1/text-to-sfx", data={"prompt": "x"}) == "t1"
+    assert route.calls.last.request.headers["authorization"] == "Bearer sk-from-file"
+
+
+@respx.mock
+async def test_streaming_generation_uses_the_stored_credential(output_dir):
+    from sonilo_mcp.credentials import credentials_path
+    _write_credentials(credentials_path(), api_key="sk-from-file")
+
+    ndjson = (
+        json.dumps({
+            "type": "audio_chunk", "stream_index": 0, "num_streams": 1,
+            "data": base64.b64encode(b"x").decode(),
+        }) + "\n"
+        + json.dumps({"type": "complete"}) + "\n"
+    ).encode()
+    route = respx.post("https://api.sonilo.com/v1/text-to-music").mock(
+        return_value=httpx.Response(200, content=ndjson)
+    )
+    from sonilo_mcp.api import _post_streaming_generation
+    await _post_streaming_generation(
+        "/v1/text-to-music", output_dir, data={"prompt": "p", "duration": 5}
+    )
+    assert route.calls.last.request.headers["authorization"] == "Bearer sk-from-file"

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,118 @@
+"""The credential reader shared with `sonilo login`."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+BASE = "https://api.sonilo.com"
+
+
+def _write(path: Path, api_base: str = BASE, api_key: str = "sk-stored", version: int = 1):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "version": version,
+                "credentials": {
+                    api_base: {
+                        "api_key": api_key,
+                        "key_id": "key-1",
+                        "account_id": "acct-1",
+                        "account_name": "Acme",
+                        "expires_at": "2026-11-09T04:12:00Z",
+                        "created_at": "2026-08-11T04:12:00Z",
+                        "created_by": "sonilo-cli/0.12.0",
+                    }
+                },
+            }
+        )
+    )
+
+
+def test_path_honours_xdg(monkeypatch, tmp_path):
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "x"))
+    from sonilo_mcp.credentials import credentials_path
+
+    assert credentials_path() == tmp_path / "x" / "sonilo" / "credentials.json"
+
+
+def test_path_falls_back_to_home_config(monkeypatch, tmp_path):
+    """Without XDG_CONFIG_HOME the CLIs use ~/.config — the same default."""
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "h"))
+    from sonilo_mcp.credentials import credentials_path
+
+    assert credentials_path() == tmp_path / "h" / ".config" / "sonilo" / "credentials.json"
+
+
+def test_reads_the_key_for_the_matching_base(tmp_path):
+    from sonilo_mcp.credentials import credentials_path, read_api_key
+
+    _write(credentials_path())
+    assert read_api_key(BASE) == "sk-stored"
+
+
+def test_returns_none_when_no_file(tmp_path):
+    from sonilo_mcp.credentials import read_api_key
+
+    assert read_api_key(BASE) is None
+
+
+def test_staging_base_does_not_see_the_production_key(tmp_path):
+    from sonilo_mcp.credentials import credentials_path, read_api_key
+
+    _write(credentials_path())
+    assert read_api_key("https://api.staging.sonilo.com") is None
+
+
+def test_newer_format_is_refused_rather_than_guessed(tmp_path):
+    from sonilo_mcp.credentials import credentials_path, read_api_key
+
+    _write(credentials_path(), version=99)
+    assert read_api_key(BASE) is None
+
+
+def test_corrupt_file_reads_as_none(tmp_path):
+    from sonilo_mcp.credentials import credentials_path, read_api_key
+
+    p = credentials_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("{ not json")
+    assert read_api_key(BASE) is None
+
+
+def test_empty_key_reads_as_none(tmp_path):
+    """An entry present but blank must not authenticate as an empty Bearer."""
+    from sonilo_mcp.credentials import credentials_path, read_api_key
+
+    _write(credentials_path(), api_key="")
+    assert read_api_key(BASE) is None
+
+
+def test_result_is_cached_between_calls(tmp_path):
+    from sonilo_mcp.credentials import credentials_path, read_api_key
+
+    p = credentials_path()
+    _write(p)
+    assert read_api_key(BASE) == "sk-stored"
+
+    # Same mtime and size: the cached value stands. This is what stops a file
+    # read on every single tool call.
+    st = p.stat()
+    _write(p, api_key="sk-different")
+    os.utime(p, ns=(st.st_atime_ns, st.st_mtime_ns))
+    if p.stat().st_size == st.st_size:
+        assert read_api_key(BASE) == "sk-stored"
+
+
+def test_cache_refreshes_after_a_real_change(tmp_path):
+    from sonilo_mcp.credentials import credentials_path, read_api_key
+
+    p = credentials_path()
+    _write(p)
+    assert read_api_key(BASE) == "sk-stored"
+
+    _write(p, api_key="sk-rotated-and-longer-than-before")
+    os.utime(p, None)
+    assert read_api_key(BASE) == "sk-rotated-and-longer-than-before"

--- a/uv.lock
+++ b/uv.lock
@@ -1225,7 +1225,7 @@ wheels = [
 
 [[package]]
 name = "sonilo-mcp"
-version = "0.10.0"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -1246,7 +1246,7 @@ dev = [
 requires-dist = [
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.2" },
     { name = "httpx", specifier = ">=0.27" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.6.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.6.0,<2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21" },

--- a/uv.lock
+++ b/uv.lock
@@ -1225,7 +1225,7 @@ wheels = [
 
 [[package]]
 name = "sonilo-mcp"
-version = "0.15.0"
+version = "0.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## What this does

`sonilo-mcp` now takes its key from the credential file written by `sonilo login` when `SONILO_API_KEY` is absent, so a host config can carry no secret at all:

```bash
claude mcp add sonilo -- uvx sonilo-mcp
codex mcp add sonilo -- uvx sonilo-mcp
```

This is what makes those two commands honest — they only work once this wheel is on PyPI, which is why the `/mcp` landing page has been held back from printing them.

## How

- **`src/sonilo_mcp/credentials.py`** (new) — read-only, stdlib-only reader for `$XDG_CONFIG_HOME/sonilo/credentials.json` (default `~/.config/sonilo/...`), the same file `sonilo-cli` 0.12.0 writes. Cached on `(path, mtime_ns, size)`: `_get_config()` runs on **every** tool call, so an uncached reader would `open()` the file constantly. Never writes, never repairs, never raises — a corrupt or newer-format file reads as "no credential" rather than a guess.
- **`_get_config()`** gains `os.getenv("SONILO_API_KEY") or read_api_key(api_url.rstrip("/"))`. The lookup is keyed by the server's own `SONILO_API_URL`, so a staging server cannot pick up a production sign-in, and the trailing slash is stripped because that is how the CLIs key the store.
- **The three duplicated key gates collapse into `_require_api_key()`.** They were byte-identical in `_http_get_json`, `_post_streaming_generation` and `_post_task_submit`; a missed one would have left exactly one tool family unable to use a sign-in, so there is a separate test per helper.

## Compatibility

`SONILO_API_KEY` still wins. Every existing host config resolves to the same account after upgrading — that precedence is a test, not a comment.

## Notes for review

- The credential path deliberately bypasses `_is_within_base`. That confinement exists to stop *caller-supplied* paths escaping `SONILO_MCP_BASE_PATH`; this path is fixed in code, no tool argument can influence it, and the credential living outside `~/Desktop` is the point. The module docstring says so.
- `tests/conftest.py`'s autouse fixture now sandboxes `$HOME` and `$XDG_CONFIG_HOME`. Without it the suite would read the developer's own credential file and pass or fail depending on whether they happened to be signed in. `test_get_config_defaults` still passes because it computes its expectation from `Path.home()` too — checked, not assumed.
- No new dependencies, so `uv.lock` is untouched and CI's `--frozen` stays valid.

## Verification

339 tests pass (18 new). Verified against **production**, not just mocks:

- credential file with a deliberately fake key, no env var → the request reached `api.sonilo.com` and came back `401` → `Invalid SONILO_API_KEY`. The file was read and its key was sent, which is the whole feature.
- no credential and no env var → `SONILO_API_KEY not set and no stored credential found — run \`sonilo login\`, or create a key at …`

The full browser-login drive (`sonilo login` → tools working with no env var) needs a human session and comes before tagging `v0.16.0`.