### PR TITLE
fix: SONILO_API_KEY is no longer required in the registry manifest

### DIFF
--- a/server.json
+++ b/server.json
@@ -19,8 +19,8 @@
       "environmentVariables": [
         {
           "name": "SONILO_API_KEY",
-          "description": "Sonilo API key from platform.sonilo.com/dashboard/api-keys",
-          "isRequired": true,
+          "description": "Sonilo API key from platform.sonilo.com/dashboard/api-keys. Optional: leave it unset to use the credential written by `sonilo login`.",
+          "isRequired": false,
           "format": "string",
           "isSecret": true
         },


### PR DESCRIPTION
One field. `server.json` is what MCP-aware installers read to decide which environment variables to demand before a server will run, and it still marked `SONILO_API_KEY` as required — a secret that 0.16.0 exists to make unnecessary, since the server now falls back to the credential written by `sonilo login`.

Must land before the `v0.16.0` tag, because the registry publish reads `server.json` from the tagged commit.

The stale `0.9.0` version fields are left alone on purpose: `publish-mcp.yml` rewrites both from the tag at publish time.