### PR TITLE
docs: pt_br, es_419 and th are dubbing targets (0.20.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sonilo-mcp"
-version = "0.20.0"
+version = "0.20.1"
 description = "MCP server for Sonilo AI music generation API"
 authors = [{ name = "Sonilo", email = "support@sonilo.com" }]
 readme = "README.md"


### PR DESCRIPTION
Version bump for #32, which is already on `main`. Publishing is tag-driven and `release.yml` verifies the tag against `pyproject.toml`, so the version has to land first.

Patch rather than minor: no tool signature changed, and nothing here validates language codes, so an installed 0.20.0 already reaches the three new languages. What it cannot do is *suggest* them — the tool description is the list a model reads when it picks one — and that is what shipping this fixes.

`server.json` is deliberately untouched: `publish-mcp.yml` rewrites its version from the tag at publish time.

After merge: `git tag v0.20.1 && git push origin v0.20.1`.

The languages are live and verified end to end — a real job through `api.sonilo.com` returned playable `th`, `pt_br` and `es_419` mp4s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)