### PR TITLE
Release 0.20.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sonilo-mcp"
-version = "0.20.1"
+version = "0.20.2"
 description = "MCP server for Sonilo AI music generation API"
 authors = [{ name = "Sonilo", email = "support@sonilo.com" }]
 readme = "README.md"


### PR DESCRIPTION
Version bump to ship the two description fixes merged in #34.

`0.20.1` → **0.20.2**, patch. Only `pyproject.toml` changes — the publish workflow syncs `server.json`'s version from the tag.

## What ships

**`ar`, `tr`, `vi`, `id` as dubbing targets.** An installed 0.20.1 already *reaches* all seventeen languages — the tool passes `languages` through without validating, and the backend does the accepting. What it cannot do is **suggest** the four new ones, because the description is the list a model reads when it picks a language.

**Dubbing's duration cap: 180s → 300s.** The same shape of bug with a worse effect. It told the model dubbing caps at 180 seconds when the real limit is 300, so a model would decline a 200-second source it could have dubbed, or trim one that needed no trimming — never reaching the local pre-check, which had the right value (`_DUBBING_MAX_VIDEO_DURATION_SECONDS = 300`) all along.

## Verification

368 tests pass. The backend side is live and verified end-to-end: a real `ar` dub returned a playable file, and the four codes resolve to exact HeyGen language names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)